### PR TITLE
Include stddef.h in iostream.h

### DIFF
--- a/include/libdivecomputer/iostream.h
+++ b/include/libdivecomputer/iostream.h
@@ -22,6 +22,7 @@
 #ifndef DC_IOSTREAM_H
 #define DC_IOSTREAM_H
 
+#include <stddef.h>
 #include <libdivecomputer/common.h>
 #include <libdivecomputer/context.h>
 


### PR DESCRIPTION
This header need to be included to successfully generate Go-bindings.