### PR TITLE
Windows dependencies to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,37 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt-get install gcc-mingw-w64 binutils-mingw-w64 mingw-w64-tools
+      - name: Install libusb
+        env:
+          LIBUSB_VERSION: 1.0.24
+        run: |
+          wget -c https://github.com/libusb/libusb/archive/refs/tags/v${LIBUSB_VERSION}.tar.gz
+          tar xzf v${LIBUSB_VERSION}.tar.gz
+          pushd libusb-${LIBUSB_VERSION}
+          autoreconf --install --force
+          ./configure --host=${{ matrix.arch }}-w64-mingw32 --prefix=/usr
+          make
+          make install DESTDIR=$PWD/../artifacts
+          popd
+      - name: Install hidapi
+        env:
+          HIDAPI_VERSION: 0.10.1
+        run: |
+          wget -c https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${HIDAPI_VERSION}.tar.gz
+          tar xzf hidapi-${HIDAPI_VERSION}.tar.gz
+          pushd hidapi-hidapi-${HIDAPI_VERSION}
+          autoreconf --install --force
+          ./configure --host=${{ matrix.arch }}-w64-mingw32 --prefix=/usr
+          make
+          make install DESTDIR=$PWD/../artifacts
+          popd
       - run: autoreconf --install --force
       - run: ./configure --host=${{ matrix.arch }}-w64-mingw32 --prefix=/usr
+        env:
+          PKG_CONFIG_LIBDIR: ${{ github.workspace }}/artifacts/usr/lib/pkgconfig
+          PKG_CONFIG_SYSROOT_DIR: ${{ github.workspace }}/artifacts
+          PKG_CONFIG_ALLOW_SYSTEM_CFLAGS: 1
+          PKG_CONFIG_ALLOW_SYSTEM_LIBS: 1
       - run: make
       - run: make distcheck
       - name: Package artifacts


### PR DESCRIPTION
# What has been done

- Add building libusb and hidapi to the windows github actions workflow. 

# How to test

- Green build pipeline
- Check the "configure" step
- See all transports  enabled like below, except BLE, which isn't implemented in libdivecomputer.
```
  Transports:

    Serial    : yes
    USB       : yes
    USBHID    : yes
    IrDA      : yes
    Bluetooth : yes
    BLE       : no
```