### PR TITLE
select(2) is found in sys/select.h

### DIFF
--- a/src/serial_posix.c
+++ b/src/serial_posix.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>	// fcntl
 #include <termios.h>	// tcgetattr, tcsetattr, cfsetispeed, cfsetospeed, tcflush, tcsendbreak
 #include <sys/ioctl.h>	// ioctl
+#include <sys/select.h>	// select
 #ifdef HAVE_LINUX_SERIAL_H
 #include <linux/serial.h>
 #endif


### PR DESCRIPTION
Namely, NetBSD.

This is what it took to build libdivecomputer 0.7.0 with pkgsrc.