### PR TITLE
Add support for the Cressi Nepto.

### DIFF
--- a/examples/dctool_timesync.c
+++ b/examples/dctool_timesync.c
@@ -85,10 +85,10 @@ do_timesync (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t 
 	}
 
 	// Syncronize the device clock.
-	message ("Syncronize the device clock.\n");
+	message ("Synchronize the device clock.\n");
 	rc = dc_device_timesync (device, datetime);
 	if (rc != DC_STATUS_SUCCESS) {
-		ERROR ("Error syncronizing the device clock.");
+		ERROR ("Error synchronizing the device clock.");
 		goto cleanup;
 	}
 

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -34,6 +34,7 @@
 
 #define CMD_VERSION        0x00
 #define CMD_SET_TIME       0x13
+#define CMD_EXIT_PCLINK    0x1D
 #define CMD_LOGBOOK        0x21
 #define CMD_DIVE           0x22
 #define CMD_LOGBOOK_V4     0x23
@@ -62,6 +63,7 @@ typedef struct cressi_goa_device_t {
 static dc_status_t cressi_goa_device_set_fingerprint (dc_device_t *abstract, const unsigned char data[], unsigned int size);
 static dc_status_t cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, void *userdata);
 static dc_status_t cressi_goa_device_timesync (dc_device_t *abstract, const dc_datetime_t *datetime);
+static dc_status_t cressi_goa_device_close (dc_device_t *abstract);
 static const dc_device_vtable_t cressi_goa_device_vtable = {
 	sizeof(cressi_goa_device_t),
 	DC_FAMILY_CRESSI_GOA,
@@ -71,7 +73,7 @@ static const dc_device_vtable_t cressi_goa_device_vtable = {
 	NULL, /* dump */
 	cressi_goa_device_foreach, /* foreach */
 	cressi_goa_device_timesync, /* timesync */
-	NULL /* close */
+	cressi_goa_device_close /* close */
 };
 
 static dc_status_t
@@ -622,6 +624,16 @@ static dc_status_t cressi_goa_device_timesync (dc_device_t *abstract, const dc_d
 	status = cressi_goa_device_transfer (device, CMD_SET_TIME, new_time, 7, NULL, 0, NULL, NULL);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to set the new time.");
+	}
+	return status;
+}
+
+static dc_status_t cressi_goa_device_close (dc_device_t *abstract)
+{
+	cressi_goa_device_t *device = (cressi_goa_device_t *) abstract;
+	dc_status_t status = cressi_goa_device_transfer (device, CMD_EXIT_PCLINK, NULL, 0, NULL, 0, NULL, NULL);
+	if (status != DC_STATUS_SUCCESS) {
+		ERROR (abstract->context, "Failed to exit PC Link.");
 	}
 	return status;
 }

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -42,7 +42,7 @@
 #define ACK     0x06
 
 #define SZ_DATA   512
-#define SZ_PACKET 10
+#define SZ_PACKET 12
 #define SZ_HEADER 23
 
 #define FP_OFFSET 0x11
@@ -389,13 +389,37 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	dc_event_progress_t progress = EVENT_PROGRESS_INITIALIZER;
 	device_event_emit (abstract, DC_EVENT_PROGRESS, &progress);
 
+	static const struct {
+		unsigned int idlen;
+		unsigned int logbook_entry_len;
+		unsigned int logbook_fp_offset;
+		unsigned int dive_fp_offset;
+		unsigned char cmd_logbook;
+	} *conf, version_differences[] = {
+		{  9, SZ_HEADER, FP_OFFSET, FP_OFFSET, CMD_LOGBOOK },
+		/*   11 is the new response length to the `CMD_VERSION` command
+		 *   15 is the length of an entry in the Logbook
+		 *    3 is the offset to the START date in the Logbook header
+		 *    9 is the offset to the START date in the Dive header
+		 * 0x23 is the new command to request the Logbook
+		 */
+		{ 11,        15,         3,         9,        0x23 },
+	};
+
+	size_t version = 0;
 	// Read the version information.
-	unsigned char id[9] = {0};
-	status = cressi_goa_device_transfer (device, CMD_VERSION, NULL, 0, id, sizeof(id), NULL, NULL);
+	unsigned char id[11] = {0};
+	for (; version < C_ARRAY_SIZE(version_differences); version++) {
+		status = cressi_goa_device_transfer (device, CMD_VERSION, NULL, 0, id, version_differences[version].idlen, NULL, NULL);
+		if (status == DC_STATUS_SUCCESS) {
+			break;
+		}
+	}
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to read the version information.");
 		goto error_exit;
 	}
+	conf = &version_differences[version];
 
 	// Emit a vendor event.
 	dc_event_vendor_t vendor;
@@ -418,11 +442,18 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	}
 
 	// Read the logbook data.
-	status = cressi_goa_device_transfer (device, CMD_LOGBOOK, NULL, 0, NULL, 0, logbook, &progress);
+	unsigned char *entries = NULL, entries_[2] = {0};
+	unsigned int esize = 0;
+	if (version == 1) {
+		entries = entries_;
+		esize = sizeof(entries_);
+	}
+	status = cressi_goa_device_transfer (device, conf->cmd_logbook, NULL, 0, entries, esize, logbook, &progress);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to read the logbook data.");
 		goto error_free_logbook;
 	}
+	unsigned int logbook_entries = array_uint16_le(entries);
 
 	const unsigned char *logbook_data = dc_buffer_get_data(logbook);
 	size_t logbook_size = dc_buffer_get_size(logbook);
@@ -430,9 +461,9 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	// Count the number of dives.
 	unsigned int count = 0;
 	unsigned int offset = logbook_size;
-	while (offset > SZ_HEADER) {
+	while (offset > conf->logbook_entry_len) {
 		// Move to the start of the logbook entry.
-		offset -= SZ_HEADER;
+		offset -= conf->logbook_entry_len;
 
 		// Get the dive number.
 		unsigned int number= array_uint16_le (logbook_data + offset);
@@ -440,7 +471,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 			break;
 
 		// Compare the fingerprint to identify previously downloaded entries.
-		if (memcmp (logbook_data + offset + FP_OFFSET, device->fingerprint, sizeof(device->fingerprint)) == 0) {
+		if (memcmp (logbook_data + offset + conf->logbook_fp_offset, device->fingerprint, sizeof(device->fingerprint)) == 0) {
 			break;
 		}
 
@@ -462,7 +493,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	offset = logbook_size;
 	for (unsigned int i = 0; i < count; ++i) {
 		// Move to the start of the logbook entry.
-		offset -= SZ_HEADER;
+		offset -= conf->logbook_entry_len;
 
 		// Read the dive data.
 		status = cressi_goa_device_transfer (device, CMD_DIVE, logbook_data + offset, 2, NULL, 0, dive, &progress);
@@ -474,20 +505,68 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		const unsigned char *dive_data = dc_buffer_get_data (dive);
 		size_t dive_size = dc_buffer_get_size (dive);
 
-		// Verify the header in the logbook and dive data are identical.
-		// After the 2 byte dive number, the logbook header has 5 bytes
-		// extra, which are not present in the dive header.
-		if (dive_size < SZ_HEADER - 5 ||
-			memcmp (dive_data + 0, logbook_data + offset + 0, 2) != 0 ||
-			memcmp (dive_data + 2, logbook_data + offset + 7, SZ_HEADER - 7) != 0) {
-			ERROR (abstract->context, "Unexpected dive header.");
-			status = DC_STATUS_DATAFORMAT;
-			goto error_free_dive;
+		if (version == 0) {
+			// Verify the header in the logbook and dive data are identical.
+			// After the 2 byte dive number, the logbook header has 5 bytes
+			// extra, which are not present in the dive header.
+			if (dive_size < SZ_HEADER - 5 ||
+				memcmp (dive_data + 0, logbook_data + offset + 0, 2) != 0 ||
+				memcmp (dive_data + 2, logbook_data + offset + 7, SZ_HEADER - 7) != 0) {
+				ERROR (abstract->context, "Unexpected dive header.");
+				status = DC_STATUS_DATAFORMAT;
+				goto error_free_dive;
+			}
+		} else {
+			/* The header format is as follows:
+			 *
+			 *  ID  | SAMPLES | START | RATE | TARA | SESSION | DIPS | unused | ...
+			 *  u16 |   u16   |  DATE |  u8  |  u8  |   u16   |  u8  |   u8   | ...
+			 *
+			 *  ... MAXDEPTH | MINTEMP | SURFTIME | DIVETIME | BESTDIP | CRC
+			 *  ...    u16   |   u16   |    u16   |    u16   |   u16   | u16
+			 *
+			 *  START = A Date in the "default" byte-wise form u16u8u8u8u8 for YMDhm
+			 *  RATE = SampleRate - 02 means seconds AFAICT
+			 *  TARA = Taravana Factor
+			 *  SESSION = Session Time
+			 *  DIPS = Number of Dips/Dives in this session
+			 */
+			unsigned short log_entry = array_uint16_le(logbook_data + offset);
+			unsigned short log_entry_ = array_uint16_le(dive_data);
+			if (log_entry_ != log_entry) {
+				ERROR (abstract->context, "Unexpected log entry %d != %d.", log_entry_, log_entry);
+				status = DC_STATUS_DATAFORMAT;
+				goto error_free_dive;
+			}
+			const unsigned char *start_date = logbook_data + offset + 3;
+			if (memcmp(dive_data + 4, start_date, 6) != 0) {
+				unsigned long long is = array_uint64_be(dive_data + 4);
+				unsigned long long should = array_uint64_be(start_date);
+				is >>= 16;
+				should >>= 16;
+				ERROR (abstract->context, "Unexpected start date 0x%0llx != 0x%0llx.", is, should);
+				status = DC_STATUS_DATAFORMAT;
+				goto error_free_dive;
+			}
+			unsigned short num_dips = dive_data[14];
+			DEBUG (abstract->context, "Received %zu bytes of data for dip %d with %d samples.",
+					dc_buffer_get_size (dive),
+					array_uint16_le(dc_buffer_get_data (dive)),
+					num_dips);
+			/* Cut off the dip details that come at the end
+			 * If we'd ever want to use that, the structure is:
+			 *
+			 * SURFTIME | MAXDEPTH | DIPTIME | MINTEMP | SPEED_DESC | SPEED_ASC | TARAVANA_VIOLATION
+			 *   u16    |   u16    |   u16   |   u16   |    u16     |    u16    |       bool
+			 */
+			dc_buffer_slice(dive, 0, dive_size - (num_dips * 13));
 		}
 
 		// Those 5 extra bytes contain the dive mode, which is required for
-		// parsing the dive data. Therefore, insert all 5 bytes again. The
-		// remaining 4 bytes appear to be some 32 bit address.
+		// parsing the dive data. Therefore, insert 5 bytes again. The
+		// trailing 4 bytes are currently not used but preserved.
+		// In the old version those 4 bytes contain "some 32bit address",
+		// in the new version they contain the upper 4 bytes of the START date.
 		if (!dc_buffer_insert (dive, 2, logbook_data + offset + 2, 5)) {
 			ERROR (abstract->context, "Out of memory.");
 			status = DC_STATUS_NOMEMORY;
@@ -497,7 +576,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		dive_data = dc_buffer_get_data (dive);
 		dive_size = dc_buffer_get_size (dive);
 
-		if (callback && !callback(dive_data, dive_size, dive_data + FP_OFFSET, sizeof(device->fingerprint), userdata))
+		if (callback && !callback(dive_data, dive_size, dive_data + conf->dive_fp_offset, sizeof(device->fingerprint), userdata))
 			break;
 	}
 

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -354,6 +354,14 @@ cressi_goa_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t c
 				if (callback) callback (DC_SAMPLE_DEPTH, &sample, userdata);
 			}
 			time += value - t;
+			if (divemode == FREEDIVE_ADV && t) {
+				// Time (seconds).
+				sample.time = time * 1000;
+				if (callback) callback (DC_SAMPLE_TIME, &sample, userdata);
+				// Depth (1/10 m).
+				sample.depth = depth / 10.0;
+				if (callback) callback (DC_SAMPLE_DEPTH, &sample, userdata);
+			}
 		}
 
 		if (complete) {

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -20,28 +20,11 @@
  */
 
 #include <stdlib.h>
-#include <stdbool.h>
 
 #include "cressi_goa.h"
 #include "context-private.h"
 #include "parser-private.h"
 #include "array.h"
-
-/* One major difference between 'libdc' of Subsurface and upstream
- * 'libdivecomputer' is the open discussion on String-based interfaces.
- * Let's (ab)use this to determine whether we're building for Subsurface.
- */
-#ifdef SAMPLE_EVENT_STRING
-/* Subsurface currently only handles sample rates of equal seconds.
- * We need to make sure that we only report events on equal seconds.
- */
-#define SUBSURFACE_ACCEPTABLE(interval, time) (((interval) != 1) || (((time) % 2) == 0))
-#define SUBSURFACE_CORRECTION(interval, time) (((interval) == 1) && (((time) % 2) == 1))
-#else
-/* libdivecomputer can deal with sub-second sample rates. */
-#define SUBSURFACE_ACCEPTABLE(interval, time) (true)
-#define SUBSURFACE_CORRECTION(interval, time) (false)
-#endif
 
 #define ISINSTANCE(parser) dc_device_isinstance((parser), &cressi_goa_parser_vtable)
 
@@ -58,16 +41,13 @@
 #define GAUGE        3
 #define FREEDIVE_ADV 5
 
-#define NGASMIXES 3
+#define NGASMIXES  3
+#define NVERSIONS  5
+#define NDIVEMODES 6
 
 #define UNDEFINED 0xFFFFFFFF
 
 typedef struct cressi_goa_parser_t cressi_goa_parser_t;
-
-struct cressi_goa_parser_t {
-	dc_parser_t base;
-	unsigned int model;
-};
 
 typedef struct cressi_goa_layout_t {
 	unsigned int headersize;
@@ -78,9 +58,18 @@ typedef struct cressi_goa_layout_t {
 	unsigned int maxdepth;
 	unsigned int avgdepth;
 	unsigned int temperature;
+	unsigned int samplerate;
+	unsigned int samplenumber;
+} cressi_goa_layout_t;
+
+struct cressi_goa_parser_t {
+	dc_parser_t base;
+	const cressi_goa_layout_t *layout;
+	unsigned int model;
 	unsigned int version;
 	unsigned int data_start;
-} cressi_goa_layout_t;
+	unsigned int divemode;
+};
 
 static dc_status_t cressi_goa_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime);
 static dc_status_t cressi_goa_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value);
@@ -109,8 +98,8 @@ static const cressi_goa_layout_t layouts_original[] = {
 		0x4E, /* maxdepth */
 		0x50, /* avgdepth */
 		0x52, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
+		UNDEFINED, /* samplerate */
+		UNDEFINED, /* samplenumber */
 	},
 	/* NITROX */
 	{
@@ -122,8 +111,8 @@ static const cressi_goa_layout_t layouts_original[] = {
 		0x4E, /* maxdepth */
 		0x50, /* avgdepth */
 		0x52, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
+		UNDEFINED, /* samplerate */
+		UNDEFINED, /* samplenumber */
 	},
 	/* FREEDIVE */
 	{
@@ -135,8 +124,8 @@ static const cressi_goa_layout_t layouts_original[] = {
 		0x1C, /* maxdepth */
 		UNDEFINED, /* avgdepth */
 		0x1E, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
+		UNDEFINED, /* samplerate */
+		UNDEFINED, /* samplenumber */
 	},
 	/* GAUGE */
 	{
@@ -148,235 +137,332 @@ static const cressi_goa_layout_t layouts_original[] = {
 		0x1D, /* maxdepth */
 		0x1F, /* avgdepth */
 		0x21, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
+		UNDEFINED, /* samplerate */
+		UNDEFINED, /* samplenumber */
 	},
 };
 
-static const cressi_goa_layout_t scuba_nitrox_layouts[] = {
-	/* v0 */
+static const cressi_goa_layout_t scuba_nitrox_layout_v0 = {
+	90, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
+	30, /* atmospheric */
+	73, /* maxdepth */
+	75, /* avgdepth */
+	77, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t scuba_nitrox_layout_v1v2 = {
+	92, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
+	30, /* atmospheric */
+	73, /* maxdepth */
+	75, /* avgdepth */
+	77, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t scuba_nitrox_layout_v3 = {
+	92, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ 26, 28, 87 }, /* gasmix[0..2] */
+	30, /* atmospheric */
+	73, /* maxdepth */
+	75, /* avgdepth */
+	77, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t scuba_nitrox_layout_v4 = {
+	82, /* headersize */
+	4, /* datetime */
+	11, /* divetime */
+	{ 17, 19, 21 }, /* gasmix[0..2] */
+	23, /* atmospheric */
+	66, /* maxdepth */
+	68, /* avgdepth */
+	70, /* temperature */
+	10, /* samplerate */
+	2, /* samplenumber */
+};
+
+static const cressi_goa_layout_t freedive_layout_v0 = {
+	34, /* headersize */
+	12, /* datetime */
+	20, /* sessiontime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	UNDEFINED, /* atmospheric */
+	23, /* maxdepth */
+	UNDEFINED, /* avgdepth */
+	25, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t freedive_layout_v1v2v3 = {
+	38, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	UNDEFINED, /* atmospheric */
+	23, /* maxdepth */
+	UNDEFINED, /* avgdepth */
+	25, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t freedive_layout_v4 = {
+	27, /* headersize */
+	4, /* datetime */
+	11, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	UNDEFINED, /* atmospheric */
+	15, /* maxdepth */
+	UNDEFINED, /* avgdepth */
+	17, /* temperature */
+	10, /* samplerate */
+	2, /* samplenumber */
+};
+
+static const cressi_goa_layout_t gauge_layout_v0 = {
+	38, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	22, /* atmospheric */
+	24, /* maxdepth */
+	26, /* avgdepth */
+	28, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t gauge_layout_v1v2v3 = {
+	38, /* headersize */
+	12, /* datetime */
+	20, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	22, /* atmospheric */
+	24, /* maxdepth */
+	26, /* avgdepth */
+	28, /* temperature */
+	UNDEFINED, /* samplerate */
+	10, /* samplenumber */
+};
+static const cressi_goa_layout_t gauge_layout_v4 = {
+	28, /* headersize */
+	4, /* datetime */
+	11, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	13, /* atmospheric */
+	15, /* maxdepth */
+	17, /* avgdepth */
+	19, /* temperature */
+	10, /* samplerate */
+	2, /* samplenumber */
+};
+
+static const cressi_goa_layout_t advanced_freedive_layout_v4 = {
+	28, /* headersize */
+	4, /* datetime */
+	22, /* divetime */
+	{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+	UNDEFINED, /* atmospheric */
+	16, /* maxdepth */
+	UNDEFINED, /* avgdepth */
+	18, /* temperature */
+	10, /* samplerate */
+	2, /* samplenumber */
+};
+
+static const cressi_goa_layout_t * const layouts[NVERSIONS][NDIVEMODES] = {
 	{
-		90, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
-		23, /* atmospheric */
-		73, /* maxdepth */
-		75, /* avgdepth */
-		77, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
+		/* SCUBA */
+		&scuba_nitrox_layout_v0,
+		/* NITROX */
+		&scuba_nitrox_layout_v0,
+		/* FREEDIVE */
+		&freedive_layout_v0,
+		/* GAUGE */
+		&gauge_layout_v0,
+		/* Undefined */
+		NULL,
+		/* Undefined */
+		NULL,
 	},
-	/* v1-v2 */
 	{
-		92, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
-		23, /* atmospheric */
-		73, /* maxdepth */
-		75, /* avgdepth */
-		77, /* temperature */
-		UNDEFINED, /* version */
-		UNDEFINED, /* data_start */
+		/* SCUBA */
+		&scuba_nitrox_layout_v1v2,
+		/* NITROX */
+		&scuba_nitrox_layout_v1v2,
+		/* FREEDIVE */
+		&freedive_layout_v1v2v3,
+		/* GAUGE */
+		&gauge_layout_v1v2v3,
+		/* Undefined */
+		NULL,
+		/* Undefined */
+		NULL,
 	},
-	/* v3 */
 	{
-		92, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ 26, 28, 87 }, /* gasmix[0..2] */
-		23, /* atmospheric */
-		73, /* maxdepth */
-		75, /* avgdepth */
-		77, /* temperature */
-		3, /* version */
-		UNDEFINED, /* data_start */
+		/* SCUBA */
+		&scuba_nitrox_layout_v1v2,
+		/* NITROX */
+		&scuba_nitrox_layout_v1v2,
+		/* FREEDIVE */
+		&freedive_layout_v1v2v3,
+		/* GAUGE */
+		&gauge_layout_v1v2v3,
+		/* Undefined */
+		NULL,
+		/* Undefined */
+		NULL,
 	},
-	/* v4 */
 	{
-		82, /* headersize */
-		4, /* datetime */
-		11, /* divetime */
-		{ 17, 19, 21 }, /* gasmix[0..2] */
-		23, /* atmospheric */
-		66, /* maxdepth */
-		68, /* avgdepth */
-		70, /* temperature */
-		4, /* version */
-		UNDEFINED, /* data_start */
+		/* SCUBA */
+		&scuba_nitrox_layout_v3,
+		/* NITROX */
+		&scuba_nitrox_layout_v3,
+		/* FREEDIVE */
+		&freedive_layout_v1v2v3,
+		/* GAUGE */
+		&gauge_layout_v1v2v3,
+		/* Undefined */
+		NULL,
+		/* Undefined */
+		NULL,
+	},
+	{
+		/* SCUBA */
+		&scuba_nitrox_layout_v4,
+		/* NITROX */
+		&scuba_nitrox_layout_v4,
+		/* FREEDIVE */
+		&freedive_layout_v4,
+		/* GAUGE */
+		&gauge_layout_v4,
+		/* Undefined */
+		NULL,
+		/* Advanced FREEDIVE */
+		&advanced_freedive_layout_v4,
 	},
 };
 
-static const cressi_goa_layout_t freedive_layouts[] = {
-	/* v0 */
-	{
-		34, /* headersize */
-		12, /* datetime */
-		20, /* sessiontime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		UNDEFINED, /* atmospheric */
-		23, /* maxdepth */
-		UNDEFINED, /* avgdepth */
-		25, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
-	},
-	/* v1-v3 */
-	{
-		38, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		UNDEFINED, /* atmospheric */
-		23, /* maxdepth */
-		UNDEFINED, /* avgdepth */
-		25, /* temperature */
-		UNDEFINED, /* version */
-		UNDEFINED, /* data_start */
-	},
-	/* v4 */
-	{
-		27, /* headersize */
-		4, /* datetime */
-		11, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		UNDEFINED, /* atmospheric */
-		15, /* maxdepth */
-		UNDEFINED, /* avgdepth */
-		17, /* temperature */
-		4, /* version */
-		UNDEFINED, /* data_start */
-	},
-};
+static dc_status_t
+cressi_goa_irda_api_version(dc_parser_t *abstract, unsigned int model, unsigned int firmware, unsigned int *version)
+{
+	if (model > 11) {
+		ERROR (abstract->context, "Unknown model %d.", model);
+		return DC_STATUS_UNSUPPORTED;
+	}
+	int version_l;
+	if (firmware >= 161 && firmware <= 165) {
+		version_l = 0;
+	} else if (firmware >= 166 && firmware <= 169) {
+		version_l = 1;
+	} else if (firmware >= 170 && firmware <= 179) {
+		version_l = 2;
+	} else if (firmware >= 100 && firmware <= 110) {
+		version_l = 3;
+	} else if (firmware >= 200 && firmware <= 205) {
+		version_l = 4;
+	} else {
+		ERROR (abstract->context, "Unknown firmware version %d.", firmware);
+		return DC_STATUS_UNSUPPORTED;
+	}
+	const unsigned int version_support_on_model[5][11] = {
+		/* 1  2  3  4  5  6  7  8  9  10  11 */
+		{  1, 1, 0, 0, 0, 0, 0, 0, 0,  0,  0 }, /* API v0 */
+		{  1, 1, 0, 0, 0, 0, 0, 0, 0,  0,  0 }, /* API v1 */
+		{  1, 1, 0, 0, 0, 0, 0, 0, 1,  0,  0 }, /* API v2 */
+		{  1, 1, 1, 1, 1, 1, 1, 1, 1,  1,  1 }, /* API v3 */
+		{  1, 1, 0, 1, 1, 0, 0, 0, 1,  1,  0 }, /* API v4 */
+	};
+	if (!version_support_on_model[version_l][model - 1]) {
+		ERROR (abstract->context, "Firmware version %d of Model %d not known to have support for API v%d.",
+				firmware, model, version_l);
+		return DC_STATUS_UNSUPPORTED;
+	}
+	*version = version_l;
+	return DC_STATUS_SUCCESS;
+}
 
-static const cressi_goa_layout_t gauge_layouts[] = {
-	/* v0 */
-	{
-		38, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		22, /* atmospheric */
-		24, /* maxdepth */
-		26, /* avgdepth */
-		28, /* temperature */
-		0, /* version */
-		UNDEFINED, /* data_start */
-	},
-	/* v1-v3 */
-	{
-		38, /* headersize */
-		12, /* datetime */
-		20, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		22, /* atmospheric */
-		24, /* maxdepth */
-		26, /* avgdepth */
-		28, /* temperature */
-		UNDEFINED, /* version */
-		UNDEFINED, /* data_start */
-	},
-	/* v4 */
-	{
-		28, /* headersize */
-		4, /* datetime */
-		11, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		13, /* atmospheric */
-		15, /* maxdepth */
-		17, /* avgdepth */
-		19, /* temperature */
-		4, /* version */
-		UNDEFINED, /* data_start */
-	},
-};
+static dc_status_t cressi_goa_get_layout(dc_parser_t *abstract)
+{
+	dc_status_t status;
+	cressi_goa_parser_t *parser = (cressi_goa_parser_t*)abstract;
+	const unsigned char *data = abstract->data;
+	unsigned int size = abstract->size;
+	const unsigned int header_len = 4u;
 
-static const cressi_goa_layout_t advanced_freedive_layouts[] = {
-	/* Advanced FREEDIVE */
-	{
-		28, /* headersize */
-		4, /* datetime */
-		22, /* divetime */
-		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
-		UNDEFINED, /* atmospheric */
-		16, /* maxdepth */
-		UNDEFINED, /* avgdepth */
-		18, /* temperature */
-		4, /* version */
-		UNDEFINED, /* data_start */
-	},
-};
+	if (size < header_len)
+		return DC_STATUS_DATAFORMAT;
 
-static const cressi_goa_layout_t *layouts_v0[] = {
-	/* SCUBA */
-	&scuba_nitrox_layouts[0],
-	/* NITROX */
-	&scuba_nitrox_layouts[0],
-	/* FREEDIVE */
-	&freedive_layouts[0],
-	/* GAUGE */
-	&gauge_layouts[0],
-};
+	unsigned int version;
+	const cressi_goa_layout_t *layout;
+	unsigned int divemode;
+	unsigned int data_start;
 
-static const cressi_goa_layout_t *layouts_v1[] = {
-	/* SCUBA */
-	&scuba_nitrox_layouts[1],
-	/* NITROX */
-	&scuba_nitrox_layouts[1],
-	/* FREEDIVE */
-	&freedive_layouts[1],
-	/* GAUGE */
-	&gauge_layouts[1],
-};
+	if (data[0] == 0xdc && data[1] == 0xdc) {
+		const unsigned int id_len = data[3];
+		/* data[2] contains the package format version and we currently only support version 0. */
+		if (data[2] != 0x00 || size < header_len + id_len) {
+			return DC_STATUS_DATAFORMAT;
+		}
+		const unsigned char *id_data = data + header_len;
+		unsigned int model = id_data[4];
+		unsigned int firmware = array_uint16_le (id_data + 5);
+		if (id_len == 11) {
+			version = array_uint16_le (id_data + 9);
+		} else {
+			status = cressi_goa_irda_api_version(abstract, model, firmware, &version);
+			if (status != DC_STATUS_SUCCESS) {
+				return status;
+			}
+		}
 
-static const cressi_goa_layout_t *layouts_v2[] = {
-	/* SCUBA */
-	&scuba_nitrox_layouts[1],
-	/* NITROX */
-	&scuba_nitrox_layouts[1],
-	/* FREEDIVE */
-	&freedive_layouts[1],
-	/* GAUGE */
-	&gauge_layouts[1],
-};
+		const unsigned char *logbook = id_data + id_len;
+		const unsigned int logbook_len = version < 4 ? 23 : 15;
 
-static const cressi_goa_layout_t *layouts_v3[] = {
-	/* SCUBA */
-	&scuba_nitrox_layouts[2],
-	/* NITROX */
-	&scuba_nitrox_layouts[2],
-	/* FREEDIVE */
-	&freedive_layouts[1],
-	/* GAUGE */
-	&gauge_layouts[1],
-};
+		if (size < header_len + id_len + logbook_len) {
+			return DC_STATUS_DATAFORMAT;
+		}
 
-static const cressi_goa_layout_t *layouts_v4[] = {
-	/* SCUBA */
-	&scuba_nitrox_layouts[3],
-	/* NITROX */
-	&scuba_nitrox_layouts[3],
-	/* FREEDIVE */
-	&freedive_layouts[2],
-	/* GAUGE */
-	&gauge_layouts[2],
-	/* Undefined */
-	NULL,
-	/* Advanced FREEDIVE */
-	&advanced_freedive_layouts[0],
-};
+		divemode = logbook[2];
+		if (version > NVERSIONS || divemode > NDIVEMODES) {
+			ERROR (abstract->context, "Value out-of-bounds. Version %d, Divemode %d.", version, divemode);
+			return DC_STATUS_DATAFORMAT;
+		}
+		if (layouts[version][divemode] == NULL) {
+			ERROR (abstract->context, "Version %d, Divemode %d not supported.", version, divemode);
+			return DC_STATUS_UNSUPPORTED;
+		}
 
-const struct {
-	const cressi_goa_layout_t **layout;
-	size_t size;
-} layouts[] = {
-	{ layouts_v0, C_ARRAY_SIZE(layouts_v0) },
-	{ layouts_v1, C_ARRAY_SIZE(layouts_v1) },
-	{ layouts_v2, C_ARRAY_SIZE(layouts_v2) },
-	{ layouts_v3, C_ARRAY_SIZE(layouts_v3) },
-	{ layouts_v4, C_ARRAY_SIZE(layouts_v4) },
-};
+		layout = layouts[version][divemode];
+		data_start = header_len + id_len + logbook_len;
+	} else {
+		divemode = data[2];
+		if (divemode >= C_ARRAY_SIZE(layouts_original)) {
+			return DC_STATUS_DATAFORMAT;
+		}
+		layout = &layouts_original[divemode];
+		data_start = 0;
+		version = 0;
+	}
+
+	if (size < layout->headersize + data_start)
+		return DC_STATUS_DATAFORMAT;
+
+	parser->layout = layout;
+	parser->data_start = data_start;
+	parser->divemode = divemode;
+	parser->version = version;
+
+	return DC_STATUS_SUCCESS;
+}
 
 dc_status_t
 cressi_goa_parser_create (dc_parser_t **out, dc_context_t *context, const unsigned char data[], size_t size, unsigned int model)
@@ -393,134 +479,26 @@ cressi_goa_parser_create (dc_parser_t **out, dc_context_t *context, const unsign
 		return DC_STATUS_NOMEMORY;
 	}
 
+	dc_status_t status = cressi_goa_get_layout((dc_parser_t*) parser);
+	if (status != DC_STATUS_SUCCESS)
+		goto error_free;
+
 	parser->model = model;
 
 	*out = (dc_parser_t*) parser;
 
 	return DC_STATUS_SUCCESS;
-}
-
-static int
-cressi_goa_irda_api_version(dc_parser_t *abstract, dc_event_devinfo_t *devinfo)
-{
-	if (devinfo->model > 11) {
-		ERROR (abstract->context, "Unknown model %d.", devinfo->model);
-		return -1;
-	}
-	int version;
-	if (devinfo->firmware >= 161 && devinfo->firmware <= 165) {
-		version = 0;
-	} else if (devinfo->firmware >= 166 && devinfo->firmware <= 169) {
-		version = 1;
-	} else if (devinfo->firmware >= 170 && devinfo->firmware <= 179) {
-		version = 2;
-	} else if (devinfo->firmware >= 100 && devinfo->firmware <= 110) {
-		version = 3;
-	} else if ((devinfo->firmware >= 200 && devinfo->firmware <= 205)
-			|| devinfo->firmware >= 900) {
-		version = 4;
-	} else {
-		ERROR (abstract->context, "Unknown firmware version %d.", devinfo->firmware);
-		return -1;
-	}
-	const bool version_support_on_model[5][11] = {
-		/*  1      2      3      4      5      6      7      8      9      10     11  */
-		{  true,  true, false, false, false, false, false, false, false, false, false }, /* API v0 */
-		{  true,  true, false, false, false, false, false, false, false, false, false }, /* API v1 */
-		{  true,  true, false, false, false, false, false, false,  true, false, false }, /* API v2 */
-		{  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true }, /* API v3 */
-		{  true,  true, false,  true,  true, false, false, false,  true,  true, false }, /* API v4 */
-	};
-	if (!version_support_on_model[version][devinfo->model - 1]) {
-		ERROR (abstract->context, "Firmware version %d of Model %d not known to have support for API v%d.",
-				devinfo->firmware, devinfo->model, version);
-		return -1;
-	}
-	return version;
-}
-
-static dc_status_t cressi_goa_get_layout(dc_parser_t *abstract, unsigned int *divemode, cressi_goa_layout_t *layout)
-{
-	const unsigned char *data = abstract->data;
-	unsigned int size = abstract->size;
-	const unsigned int header_len = 4u;
-
-	if (size < header_len)
-		return DC_STATUS_DATAFORMAT;
-
-	unsigned int divemode_;
-
-	if (data[0] == 0xdc && data[1] == 0xdc) {
-		const unsigned int id_len = data[3];
-		/* data[2] contains the package format version and we currently only support version 0. */
-		if (data[2] != 0x00 || size < header_len + id_len) {
-			return DC_STATUS_DATAFORMAT;
-		}
-		const unsigned char *id_data = data + header_len;
-		int version;
-		if (id_len == 11) {
-			version = array_uint16_le (id_data + 9);
-		} else {
-			dc_event_devinfo_t devinfo;
-			devinfo.model = id_data[4];
-			devinfo.firmware = array_uint16_le (id_data + 5);
-			devinfo.serial = array_uint32_le (id_data + 0);
-
-			version = cressi_goa_irda_api_version(abstract, &devinfo);
-			if (version < 0) {
-				return DC_STATUS_UNSUPPORTED;
-			}
-		}
-		if ((size_t)version >= C_ARRAY_SIZE(layouts)) {
-			return DC_STATUS_UNSUPPORTED;
-		}
-
-		const unsigned char *logbook = id_data + id_len;
-		const unsigned int logbook_len = version < 4 ? 23 : 15;
-
-		if (size < header_len + id_len + logbook_len) {
-			return DC_STATUS_DATAFORMAT;
-		}
-
-		divemode_ = logbook[2];
-		if (divemode_ >= layouts[version].size) {
-			return DC_STATUS_UNSUPPORTED;
-		}
-		if (layouts[version].layout[divemode_] == NULL) {
-			return DC_STATUS_UNSUPPORTED;
-		}
-
-		*layout = *(layouts[version].layout[divemode_]);
-		layout->version = version;
-		layout->data_start = header_len + id_len + logbook_len;
-	} else {
-		divemode_ = data[2];
-		if (divemode_ >= C_ARRAY_SIZE(layouts_original)) {
-			return DC_STATUS_DATAFORMAT;
-		}
-		*layout = layouts_original[divemode_];
-		layout->data_start = 0;
-	}
-
-	if (size < layout->headersize + layout->data_start)
-		return DC_STATUS_DATAFORMAT;
-
-	if (divemode)
-		*divemode = divemode_;
-
-	return DC_STATUS_SUCCESS;
+error_free:
+	dc_parser_deallocate ((dc_parser_t *) parser);
+	return status;
 }
 
 static dc_status_t
 cressi_goa_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime)
 {
-	cressi_goa_layout_t dynamic_layout;
-	dc_status_t status = cressi_goa_get_layout(abstract, NULL, &dynamic_layout);
-	if (status != DC_STATUS_SUCCESS)
-		return status;
-	const cressi_goa_layout_t *layout = &dynamic_layout;
+	cressi_goa_parser_t *parser = (cressi_goa_parser_t*)abstract;
 
-	const unsigned char *p = abstract->data + layout->data_start + layout->datetime;
+	const unsigned char *p = abstract->data + parser->data_start + parser->layout->datetime;
 
 	if (datetime) {
 		datetime->year = array_uint16_le(p);
@@ -538,13 +516,9 @@ cressi_goa_parser_get_datetime (dc_parser_t *abstract, dc_datetime_t *datetime)
 static dc_status_t
 cressi_goa_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsigned int flags, void *value)
 {
-	unsigned int divemode;
-	cressi_goa_layout_t dynamic_layout;
-	dc_status_t status = cressi_goa_get_layout(abstract, &divemode, &dynamic_layout);
-	if (status != DC_STATUS_SUCCESS)
-		return status;
-	const cressi_goa_layout_t *layout = &dynamic_layout;
-	const unsigned char *data = abstract->data + layout->data_start;
+	cressi_goa_parser_t *parser = (cressi_goa_parser_t*)abstract;
+	const cressi_goa_layout_t *layout = parser->layout;
+	const unsigned char *data = abstract->data + parser->data_start;
 
 	unsigned int ngasmixes = 0;
 	for (unsigned int i = 0; i < NGASMIXES; ++i) {
@@ -596,7 +570,7 @@ cressi_goa_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsign
 			gasmix->nitrogen = 1.0 - gasmix->oxygen - gasmix->helium;
 			break;
 		case DC_FIELD_DIVEMODE:
-			switch (divemode) {
+			switch (parser->divemode) {
 			case SCUBA:
 			case NITROX:
 				*((dc_divemode_t *) value) = DC_DIVEMODE_OC;
@@ -620,86 +594,50 @@ cressi_goa_parser_get_field (dc_parser_t *abstract, dc_field_type_t type, unsign
 	return DC_STATUS_SUCCESS;
 }
 
-static const unsigned int cressi_goa_time_multiplier = 500;
-
-struct cressi_goa_parser_ctx {
-	dc_parser_t *abstract;
-
-	dc_sample_callback_t callback;
-	void *userdata;
-
-	bool last_depth_is_zero;
-};
-
-static void cressi_goa_parser_callback(dc_sample_type_t type, const dc_sample_value_t *value, struct cressi_goa_parser_ctx *ctx)
-{
-	if (!ctx->callback)
-		return;
-	if (type == DC_SAMPLE_DEPTH)
-		ctx->last_depth_is_zero = value->depth == 0.0;
-	ctx->callback(type, value, ctx->userdata);
-}
-
 static dc_status_t
 cressi_goa_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t callback, void *userdata)
 {
+	cressi_goa_parser_t *parser = (cressi_goa_parser_t*)abstract;
 	const unsigned char *data = abstract->data;
 	unsigned int size = abstract->size;
 
-	unsigned int divemode;
-	cressi_goa_layout_t dynamic_layout;
-	dc_status_t status = cressi_goa_get_layout(abstract, &divemode, &dynamic_layout);
-	if (status != DC_STATUS_SUCCESS)
-		return status;
-	const cressi_goa_layout_t *layout = &dynamic_layout;
+	unsigned int interval = parser->divemode == FREEDIVE ? 2000 : 5000;
 
-	struct cressi_goa_parser_ctx ctx = {0};
-	ctx.abstract = abstract;
-	ctx.callback = callback;
-	ctx.userdata = userdata;
+	unsigned int offset = parser->data_start + parser->layout->headersize;
+	const unsigned char *header = data + parser->data_start;
 
-	unsigned int interval = divemode == FREEDIVE ? 4 : 10;
-
-	unsigned int offset = layout->data_start + layout->headersize;
-
-	if (divemode == FREEDIVE_ADV) {
-		const unsigned char *header = data + layout->data_start;
-		unsigned int sample_rate = header[10];
+	if (parser->version == 4) {
+		unsigned int sample_rate = header[parser->layout->samplerate];
 		/* Valid sample rates are: 0.5s, 1s, 2s, 5s */
-		switch (sample_rate) {
-			case 1:
-				interval = 1;
-				break;
-			case 2:
-				interval = 2;
-				break;
-			case 3:
-				interval = 4;
-				break;
-			case 4:
-				interval = 10;
-				break;
-			default:
-				ERROR (abstract->context, "Unknown sample rate: 0x%02x.", sample_rate);
-				return DC_STATUS_DATAFORMAT;
+		unsigned int sample_rates[] = {
+				500, 1000, 2000, 5000
+		};
+		if (sample_rate == 0 || sample_rate > sizeof(sample_rates)) {
+			ERROR (abstract->context, "Unknown sample rate: 0x%02x.", sample_rate);
+			return DC_STATUS_DATAFORMAT;
 		}
-
-		/* Adjust the size in order to skip the Advanced Freedive Dip Stats that come at the end.
-		 * If we'd ever want to use those, the structure is:
-		 *
-		 * SURFTIME | MAXDEPTH | DIPTIME | MINTEMP | SPEED_DESC | SPEED_ASC | TARAVANA_VIOLATION
-		 *   u16    |   u16    |   u16   |   u16   |    u16     |    u16    |       bool
-		 */
-		unsigned int num_samples = array_uint16_le (header + 2);
-		size = offset + num_samples * 2;
+		interval = sample_rates[sample_rate - 1];
 	}
+
+	/* Adjust the size to the number of samples reported by the DC.
+	 *
+	 * In Advanced Freedive mode, there are Advanced Freedive Dip Stats attached at the end.
+	 * Skip those for now, but if we'd ever want to use them, their structure is:
+	 *
+	 * SURFTIME | MAXDEPTH | DIPTIME | MINTEMP | SPEED_DESC | SPEED_ASC | TARAVANA_VIOLATION
+	 *   u16    |   u16    |   u16   |   u16   |    u16     |    u16    |       bool
+	 */
+	unsigned int num_samples = array_uint16_le (header + parser->layout->samplenumber);
+	size = offset + num_samples * 2;
 
 	unsigned int time = 0;
 	unsigned int depth = 0;
+	unsigned int depth_mask = ((parser->version < 4) ? 0x07FF : 0x0FFF);
 	unsigned int gasmix = 0, gasmix_previous = 0xFFFFFFFF;
+	unsigned int gasmix_mask = ((parser->version < 3) ? 0x0800 : 0x1800);
 	unsigned int temperature = 0;
-	bool have_temperature = false;
-	bool complete = false;
+	unsigned int have_temperature = 0;
+	unsigned int complete = 0;
 
 	while (offset + 2 <= size) {
 		dc_sample_value_t sample = {0};
@@ -708,88 +646,67 @@ cressi_goa_parser_samples_foreach (dc_parser_t *abstract, dc_sample_callback_t c
 		unsigned int raw = array_uint16_le (data + offset);
 		unsigned int type  = (raw & 0x0003);
 		unsigned int value = (raw & 0xFFFC) >> 2;
-		unsigned int t = 0;
 
 		if (type == DEPTH_SCUBA) {
 			depth = value & 0x7ffu;
-			gasmix = (value >> 11) & ((layout->version < 3) ? 0x1u : 0x3u);
-			/* speed_level = (layout->version < 3) ? (raw >> 14) & 0x3u : 0; */
+			gasmix = (value & gasmix_mask) >> 13;
 			time += interval;
-			complete = true;
+			complete = 1;
 		} else if (type == DEPTH_FREE) {
-			depth = value & ((layout->version < 4) ? 0x7ffu : 0xfffu);
+			depth = value & depth_mask;
 			time += interval;
-			complete = true;
+			complete = 1;
 		} else if (type == TEMPERATURE) {
 			temperature = value;
-			have_temperature = true;
+			have_temperature = 1;
 		} else if (type == SURFACE) {
 			// SURFACE values are not given in the sample rate, but as seconds
-			if (divemode == FREEDIVE_ADV && (offset + 2 < size)) {
-				if (time)
-					t = interval;
-				if (SUBSURFACE_CORRECTION(interval, (time + t)))
-					t = 2;
-				time += t;
-				depth = 0;
+			unsigned int surftime = value * 1000;
+			if (surftime > interval) {
+				surftime -= interval;
+				time += interval;
 
 				// Time (seconds).
-				sample.time = time * cressi_goa_time_multiplier;
-				cressi_goa_parser_callback (DC_SAMPLE_TIME, &sample, &ctx);
+				sample.time = time;
+				if (callback) callback (DC_SAMPLE_TIME, &sample, userdata);
 				// Depth (1/10 m).
 				sample.depth = 0.0;
-				cressi_goa_parser_callback (DC_SAMPLE_DEPTH, &sample, &ctx);
+				if (callback) callback (DC_SAMPLE_DEPTH, &sample, userdata);
 			}
-			// One `time` unit equals 500ms, so we have to multiply the `value` with 2 in order to count seconds
-			time += ((value * 2) - t);
-			if (divemode == FREEDIVE_ADV && t) {
-				unsigned int correction = SUBSURFACE_CORRECTION(interval, time) ? 1 : 0;
-				// Time (seconds).
-				sample.time = (time - correction) * cressi_goa_time_multiplier;
-				cressi_goa_parser_callback (DC_SAMPLE_TIME, &sample, &ctx);
-				// Depth (1/10 m).
-				sample.depth = 0.0;
-				cressi_goa_parser_callback (DC_SAMPLE_DEPTH, &sample, &ctx);
-			}
+			time += surftime;
+			depth = 0;
+			complete = 1;
 		}
 
-		if (complete && SUBSURFACE_ACCEPTABLE(interval, time)) {
+		if (complete) {
 			// Time (seconds).
-			sample.time = time * cressi_goa_time_multiplier;
-			cressi_goa_parser_callback (DC_SAMPLE_TIME, &sample, &ctx);
+			sample.time = time;
+			if (callback) callback (DC_SAMPLE_TIME, &sample, userdata);
 
 			// Temperature (1/10 °C).
 			if (have_temperature) {
 				sample.temperature = temperature / 10.0;
-				cressi_goa_parser_callback (DC_SAMPLE_TEMPERATURE, &sample, &ctx);
-				have_temperature = false;
+				if (callback) callback (DC_SAMPLE_TEMPERATURE, &sample, userdata);
+				have_temperature = 0;
 			}
 
 			// Depth (1/10 m).
 			sample.depth = depth / 10.0;
-			cressi_goa_parser_callback (DC_SAMPLE_DEPTH, &sample, &ctx);
+			if (callback) callback (DC_SAMPLE_DEPTH, &sample, userdata);
 
 			// Gas change
-			if (divemode == SCUBA || divemode == NITROX) {
+			if (parser->divemode == SCUBA || parser->divemode == NITROX) {
 				if (gasmix != gasmix_previous) {
 					sample.gasmix = gasmix;
-					cressi_goa_parser_callback (DC_SAMPLE_GASMIX, &sample, &ctx);
+					if (callback) callback (DC_SAMPLE_GASMIX, &sample, userdata);
 					gasmix_previous = gasmix;
 				}
 			}
 
-			complete = false;
+			complete = 0;
 		}
 
 		offset += 2;
-	}
-
-	if (!ctx.last_depth_is_zero) {
-		dc_sample_value_t sample = {0};
-		sample.time = time * cressi_goa_time_multiplier;
-		cressi_goa_parser_callback (DC_SAMPLE_TIME, &sample, &ctx);
-		sample.depth = 0.0;
-		cressi_goa_parser_callback (DC_SAMPLE_DEPTH, &sample, &ctx);
 	}
 
 	return DC_STATUS_SUCCESS;

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -414,10 +414,10 @@ cressi_goa_irda_api_version(dc_parser_t *abstract, dc_event_devinfo_t *devinfo)
 		version = 1;
 	} else if (devinfo->firmware >= 170 && devinfo->firmware <= 179) {
 		version = 2;
-	} else if ((devinfo->firmware >= 100 && devinfo->firmware <= 110)
-			|| devinfo->firmware == 900) {
+	} else if (devinfo->firmware >= 100 && devinfo->firmware <= 110) {
 		version = 3;
-	} else if (devinfo->firmware >= 200 && devinfo->firmware <= 205) {
+	} else if ((devinfo->firmware >= 200 && devinfo->firmware <= 205)
+			|| devinfo->firmware >= 900) {
 		version = 4;
 	} else {
 		ERROR (abstract->context, "Unknown firmware version %d.", devinfo->firmware);

--- a/src/cressi_goa_parser.c
+++ b/src/cressi_goa_parser.c
@@ -98,7 +98,7 @@ static const dc_parser_vtable_t cressi_goa_parser_vtable = {
 	NULL /* destroy */
 };
 
-static const cressi_goa_layout_t layouts_v0[] = {
+static const cressi_goa_layout_t layouts_original[] = {
 	/* SCUBA */
 	{
 		0x61, /* headersize */
@@ -153,8 +153,47 @@ static const cressi_goa_layout_t layouts_v0[] = {
 	},
 };
 
-static const cressi_goa_layout_t layouts_v4[] = {
-	/* SCUBA */
+static const cressi_goa_layout_t scuba_nitrox_layouts[] = {
+	/* v0 */
+	{
+		90, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
+		23, /* atmospheric */
+		73, /* maxdepth */
+		75, /* avgdepth */
+		77, /* temperature */
+		0, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v1-v2 */
+	{
+		92, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ 26, 28, UNDEFINED }, /* gasmix[0..2] */
+		23, /* atmospheric */
+		73, /* maxdepth */
+		75, /* avgdepth */
+		77, /* temperature */
+		UNDEFINED, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v3 */
+	{
+		92, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ 26, 28, 87 }, /* gasmix[0..2] */
+		23, /* atmospheric */
+		73, /* maxdepth */
+		75, /* avgdepth */
+		77, /* temperature */
+		3, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v4 */
 	{
 		82, /* headersize */
 		4, /* datetime */
@@ -167,24 +206,40 @@ static const cressi_goa_layout_t layouts_v4[] = {
 		4, /* version */
 		UNDEFINED, /* data_start */
 	},
-	/* NITROX */
+};
+
+static const cressi_goa_layout_t freedive_layouts[] = {
+	/* v0 */
 	{
-		82, /* headersize */
-		4, /* datetime */
-		11, /* divetime */
-		{ 17, 19, 21 }, /* gasmix[0..2] */
-		23, /* atmospheric */
-		66, /* maxdepth */
-		68, /* avgdepth */
-		70, /* temperature */
-		4, /* version */
+		34, /* headersize */
+		12, /* datetime */
+		20, /* sessiontime */
+		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+		UNDEFINED, /* atmospheric */
+		23, /* maxdepth */
+		UNDEFINED, /* avgdepth */
+		25, /* temperature */
+		0, /* version */
 		UNDEFINED, /* data_start */
 	},
-	/* FREEDIVE */
+	/* v1-v3 */
+	{
+		38, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+		UNDEFINED, /* atmospheric */
+		23, /* maxdepth */
+		UNDEFINED, /* avgdepth */
+		25, /* temperature */
+		UNDEFINED, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v4 */
 	{
 		27, /* headersize */
 		4, /* datetime */
-		21, /* divetime */
+		11, /* divetime */
 		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
 		UNDEFINED, /* atmospheric */
 		15, /* maxdepth */
@@ -193,7 +248,36 @@ static const cressi_goa_layout_t layouts_v4[] = {
 		4, /* version */
 		UNDEFINED, /* data_start */
 	},
-	/* GAUGE */
+};
+
+static const cressi_goa_layout_t gauge_layouts[] = {
+	/* v0 */
+	{
+		38, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+		22, /* atmospheric */
+		24, /* maxdepth */
+		26, /* avgdepth */
+		28, /* temperature */
+		0, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v1-v3 */
+	{
+		38, /* headersize */
+		12, /* datetime */
+		20, /* divetime */
+		{ UNDEFINED, UNDEFINED, UNDEFINED }, /* gasmix */
+		22, /* atmospheric */
+		24, /* maxdepth */
+		26, /* avgdepth */
+		28, /* temperature */
+		UNDEFINED, /* version */
+		UNDEFINED, /* data_start */
+	},
+	/* v4 */
 	{
 		28, /* headersize */
 		4, /* datetime */
@@ -206,8 +290,9 @@ static const cressi_goa_layout_t layouts_v4[] = {
 		4, /* version */
 		UNDEFINED, /* data_start */
 	},
-	/* Undefined */
-	{ 0 },
+};
+
+static const cressi_goa_layout_t advanced_freedive_layouts[] = {
 	/* Advanced FREEDIVE */
 	{
 		28, /* headersize */
@@ -223,14 +308,73 @@ static const cressi_goa_layout_t layouts_v4[] = {
 	},
 };
 
+static const cressi_goa_layout_t *layouts_v0[] = {
+	/* SCUBA */
+	&scuba_nitrox_layouts[0],
+	/* NITROX */
+	&scuba_nitrox_layouts[0],
+	/* FREEDIVE */
+	&freedive_layouts[0],
+	/* GAUGE */
+	&gauge_layouts[0],
+};
+
+static const cressi_goa_layout_t *layouts_v1[] = {
+	/* SCUBA */
+	&scuba_nitrox_layouts[1],
+	/* NITROX */
+	&scuba_nitrox_layouts[1],
+	/* FREEDIVE */
+	&freedive_layouts[1],
+	/* GAUGE */
+	&gauge_layouts[1],
+};
+
+static const cressi_goa_layout_t *layouts_v2[] = {
+	/* SCUBA */
+	&scuba_nitrox_layouts[1],
+	/* NITROX */
+	&scuba_nitrox_layouts[1],
+	/* FREEDIVE */
+	&freedive_layouts[1],
+	/* GAUGE */
+	&gauge_layouts[1],
+};
+
+static const cressi_goa_layout_t *layouts_v3[] = {
+	/* SCUBA */
+	&scuba_nitrox_layouts[2],
+	/* NITROX */
+	&scuba_nitrox_layouts[2],
+	/* FREEDIVE */
+	&freedive_layouts[1],
+	/* GAUGE */
+	&gauge_layouts[1],
+};
+
+static const cressi_goa_layout_t *layouts_v4[] = {
+	/* SCUBA */
+	&scuba_nitrox_layouts[3],
+	/* NITROX */
+	&scuba_nitrox_layouts[3],
+	/* FREEDIVE */
+	&freedive_layouts[2],
+	/* GAUGE */
+	&gauge_layouts[2],
+	/* Undefined */
+	NULL,
+	/* Advanced FREEDIVE */
+	&advanced_freedive_layouts[0],
+};
+
 const struct {
-	const cressi_goa_layout_t *layout;
+	const cressi_goa_layout_t **layout;
 	size_t size;
 } layouts[] = {
 	{ layouts_v0, C_ARRAY_SIZE(layouts_v0) },
-	{ NULL, 0 },
-	{ NULL, 0 },
-	{ NULL, 0 },
+	{ layouts_v1, C_ARRAY_SIZE(layouts_v1) },
+	{ layouts_v2, C_ARRAY_SIZE(layouts_v2) },
+	{ layouts_v3, C_ARRAY_SIZE(layouts_v3) },
 	{ layouts_v4, C_ARRAY_SIZE(layouts_v4) },
 };
 
@@ -267,7 +411,7 @@ static dc_status_t cressi_goa_get_layout(dc_parser_t *abstract, unsigned int *di
 	unsigned int divemode_;
 
 	unsigned char version = data[2];
-	if (data[0] == 0xdc && data[1] == 0xdc && (version == 0x00 || version == 0x04)) {
+	if (data[0] == 0xdc && data[1] == 0xdc) {
 		if (version >= C_ARRAY_SIZE(layouts)) {
 			return DC_STATUS_DATAFORMAT;
 		}
@@ -276,16 +420,19 @@ static dc_status_t cressi_goa_get_layout(dc_parser_t *abstract, unsigned int *di
 		if (divemode_ >= layouts[version].size) {
 			return DC_STATUS_DATAFORMAT;
 		}
+		if (layouts[version].layout[divemode_] == NULL) {
+			return DC_STATUS_DATAFORMAT;
+		}
 
-		*layout = layouts[version].layout[divemode_];
+		*layout = *(layouts[version].layout[divemode_]);
 		layout->version = version;
 		layout->data_start = 4 + data[3];
 	} else {
 		divemode_ = data[2];
-		if (divemode_ >= C_ARRAY_SIZE(layouts_v0)) {
+		if (divemode_ >= C_ARRAY_SIZE(layouts_original)) {
 			return DC_STATUS_DATAFORMAT;
 		}
-		*layout = layouts_v0[divemode_];
+		*layout = layouts_original[divemode_];
 		layout->data_start = 0;
 	}
 

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -343,6 +343,7 @@ static const dc_descriptor_t g_descriptors[] = {
 	{"Cressi", "Donatello",    DC_FAMILY_CRESSI_GOA, 4, DC_TRANSPORT_SERIAL, NULL},
 	{"Cressi", "Michelangelo", DC_FAMILY_CRESSI_GOA, 5, DC_TRANSPORT_SERIAL, NULL},
 	{"Cressi", "Neon",     DC_FAMILY_CRESSI_GOA, 9, DC_TRANSPORT_SERIAL, NULL},
+	{"Cressi", "Nepto",    DC_FAMILY_CRESSI_GOA, 10, DC_TRANSPORT_SERIAL, NULL},
 	/* Zeagle N2iTiON3 */
 	{"Zeagle",    "N2iTiON3",   DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},
 	{"Apeks",     "Quantum X",  DC_FAMILY_ZEAGLE_N2ITION3, 0, DC_TRANSPORT_SERIAL, NULL},

--- a/src/platform.h
+++ b/src/platform.h
@@ -36,11 +36,12 @@ extern "C" {
 
 #ifdef _WIN32
 #define DC_PRINTF_SIZE "%Iu"
-#define DC_FORMAT_INT64 "%I64d"
+#define DC_PRI_LL "I64"
 #else
 #define DC_PRINTF_SIZE "%zu"
-#define DC_FORMAT_INT64 "%lld"
+#define DC_PRI_LL "ll"
 #endif
+#define DC_FORMAT_INT64 "%" DC_PRI_LL "d"
 
 #ifdef _MSC_VER
 #define strcasecmp _stricmp


### PR DESCRIPTION
This adds support for the Cressi Nepto.

The serial protocol it uses is slightly different to the one used by the Goa, but similar enough to integrate both in the same module. I modify the generated data slightly, in order to have smoother graphs in subsurface.

Additionally I've added the option to synchronize the time and exit the PC Link mode on the dc. Those two features are currently only enabled for "IRDAv4" devices, since I don't have an older one.

Some background is summarized here: https://sjaeckel.github.io/2024/04/23/Cressi-Nepto-for-Subsurface.html