### PR TITLE
Add --count option to dctool_download

### DIFF
--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -313,7 +313,7 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 				units = DCTOOL_UNITS_IMPERIAL;
 			break;
 		case 'l':
-			limit = atoi (optarg);
+			limit = strtoul (optarg, NULL, 0);
 			break;
 		default:
 			return EXIT_FAILURE;

--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -237,7 +237,7 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 		// Generate the fingerprint filename.
 		family = dc_device_get_type (device);
 		snprintf (filename, sizeof (filename), "%s/%s-%08X.bin",
-					cachedir, dctool_family_name (family), eventdata.devinfo.serial);
+			cachedir, dctool_family_name (family), eventdata.devinfo.serial);
 
 		// Write the fingerprint file.
 		dctool_file_write (filename, ofingerprint);
@@ -329,12 +329,6 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 		return EXIT_SUCCESS;
 	}
 
-	if (fphex && limit > 0) {
-		message ("Using --limit and --fingerprint together is not allowed because it may lead to missed dives during a fingerprinted import.\n");
-		exitcode = EXIT_FAILURE;
-		goto cleanup;
-	}
-
 	// Check the transport type.
 	if (transport == DC_TRANSPORT_NONE) {
 		message ("No valid transport type specified.\n");
@@ -392,7 +386,7 @@ const dctool_command_t dctool_download = {
 	"   -c, --cache <directory>    Cache directory\n"
 	"   -f, --format <format>      Output format\n"
 	"   -u, --units <units>        Set units (metric or imperial)\n"
-	"   -l, --limit <number>       Maximum number of dives to download (not allowed with -p/--fingerprint)\n"
+	"   -l, --limit <number>       Maximum number of dives to download\n"
 #else
 	"   -h                 Show help message\n"
 	"   -t <transport>     Transport type\n"
@@ -401,7 +395,7 @@ const dctool_command_t dctool_download = {
 	"   -c <directory>     Cache directory\n"
 	"   -f <format>        Output format\n"
 	"   -u <units>         Set units (metric or imperial)\n"
-	"   -l <limit>         Maximum number of dives to download (not allowed with -p/--fingerprint)\n"
+	"   -l <limit>         Maximum number of dives to download\n"
 #endif
 	"\n"
 	"Supported output formats:\n"

--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -237,7 +237,7 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 		// Generate the fingerprint filename.
 		family = dc_device_get_type (device);
 		snprintf (filename, sizeof (filename), "%s/%s-%08X.bin",
-					cachedir, dctool_family_name (family), eventdata.devinfo.serial);
+			cachedir, dctool_family_name (family), eventdata.devinfo.serial);
 
 		// Write the fingerprint file.
 		dctool_file_write (filename, ofingerprint);

--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -53,6 +53,7 @@ typedef struct dive_data_t {
 	dc_buffer_t **fingerprint;
 	unsigned int number;
 	dctool_output_t *output;
+	unsigned int count;
 } dive_data_t;
 
 static int
@@ -92,6 +93,10 @@ dive_cb (const unsigned char *data, unsigned int size, const unsigned char *fing
 	if (rc != DC_STATUS_SUCCESS) {
 		ERROR ("Error parsing the dive data.");
 		goto cleanup;
+	}
+	
+	if (divedata->count > 0 && divedata->number >= divedata->count) {
+		return 0;
 	}
 
 cleanup:
@@ -146,7 +151,7 @@ event_cb (dc_device_t *device, dc_event_type_t event, const void *data, void *us
 }
 
 static dc_status_t
-download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t transport, const char *devname, const char *cachedir, dc_buffer_t *fingerprint, dctool_output_t *output)
+download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t transport, const char *devname, const char *cachedir, dc_buffer_t *fingerprint, dctool_output_t *output, unsigned int count)
 {
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	dc_iostream_t *iostream = NULL;
@@ -214,6 +219,7 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 	divedata.fingerprint = &ofingerprint;
 	divedata.number = 0;
 	divedata.output = output;
+	divedata.count = count;
 
 	// Download the dives.
 	message ("Downloading the dives.\n");
@@ -231,7 +237,7 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 		// Generate the fingerprint filename.
 		family = dc_device_get_type (device);
 		snprintf (filename, sizeof (filename), "%s/%s-%08X.bin",
-			cachedir, dctool_family_name (family), eventdata.devinfo.serial);
+					cachedir, dctool_family_name (family), eventdata.devinfo.serial);
 
 		// Write the fingerprint file.
 		dctool_file_write (filename, ofingerprint);
@@ -260,10 +266,11 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 	const char *filename = NULL;
 	const char *cachedir = NULL;
 	const char *format = "xml";
+	unsigned int count = 0;
 
 	// Parse the command-line options.
 	int opt = 0;
-	const char *optstring = "ht:o:p:c:f:u:";
+	const char *optstring = "ht:o:p:c:f:u:n:";
 #ifdef HAVE_GETOPT_LONG
 	struct option options[] = {
 		{"help",        no_argument,       0, 'h'},
@@ -273,6 +280,7 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 		{"cache",       required_argument, 0, 'c'},
 		{"format",      required_argument, 0, 'f'},
 		{"units",       required_argument, 0, 'u'},
+		{"count",       required_argument, 0, 'n'},
 		{0,             0,                 0,  0 }
 	};
 	while ((opt = getopt_long (argc, argv, optstring, options, NULL)) != -1) {
@@ -303,6 +311,9 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 				units = DCTOOL_UNITS_METRIC;
 			if (strcmp (optarg, "imperial") == 0)
 				units = DCTOOL_UNITS_IMPERIAL;
+			break;
+		case 'n':
+			count = atoi (optarg);
 			break;
 		default:
 			return EXIT_FAILURE;
@@ -345,7 +356,7 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 	}
 
 	// Download the dives.
-	status = download (context, descriptor, transport, argv[0], cachedir, fingerprint, output);
+	status = download (context, descriptor, transport, argv[0], cachedir, fingerprint, output, count);
 	if (status != DC_STATUS_SUCCESS) {
 		message ("ERROR: %s\n", dctool_errmsg (status));
 		exitcode = EXIT_FAILURE;
@@ -375,6 +386,7 @@ const dctool_command_t dctool_download = {
 	"   -c, --cache <directory>    Cache directory\n"
 	"   -f, --format <format>      Output format\n"
 	"   -u, --units <units>        Set units (metric or imperial)\n"
+	"   -n, --count <number>       Number of dives to download\n"
 #else
 	"   -h                 Show help message\n"
 	"   -t <transport>     Transport type\n"
@@ -383,6 +395,7 @@ const dctool_command_t dctool_download = {
 	"   -c <directory>     Cache directory\n"
 	"   -f <format>        Output format\n"
 	"   -u <units>         Set units (metric or imperial)\n"
+	"   -n <count>         Number of dives to download\n"
 #endif
 	"\n"
 	"Supported output formats:\n"

--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -237,7 +237,7 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 		// Generate the fingerprint filename.
 		family = dc_device_get_type (device);
 		snprintf (filename, sizeof (filename), "%s/%s-%08X.bin",
-			cachedir, dctool_family_name (family), eventdata.devinfo.serial);
+					cachedir, dctool_family_name (family), eventdata.devinfo.serial);
 
 		// Write the fingerprint file.
 		dctool_file_write (filename, ofingerprint);
@@ -329,6 +329,12 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 		return EXIT_SUCCESS;
 	}
 
+	if (fphex && limit > 0) {
+		message ("Using --limit and --fingerprint together is not allowed because it may lead to missed dives during a fingerprinted import.\n");
+		exitcode = EXIT_FAILURE;
+		goto cleanup;
+	}
+
 	// Check the transport type.
 	if (transport == DC_TRANSPORT_NONE) {
 		message ("No valid transport type specified.\n");
@@ -386,7 +392,7 @@ const dctool_command_t dctool_download = {
 	"   -c, --cache <directory>    Cache directory\n"
 	"   -f, --format <format>      Output format\n"
 	"   -u, --units <units>        Set units (metric or imperial)\n"
-	"   -l, --limit <number>       Maximum number of dives to download\n"
+	"   -l, --limit <number>       Maximum number of dives to download (not allowed with -p/--fingerprint)\n"
 #else
 	"   -h                 Show help message\n"
 	"   -t <transport>     Transport type\n"
@@ -395,7 +401,7 @@ const dctool_command_t dctool_download = {
 	"   -c <directory>     Cache directory\n"
 	"   -f <format>        Output format\n"
 	"   -u <units>         Set units (metric or imperial)\n"
-	"   -l <limit>         Maximum number of dives to download\n"
+	"   -l <limit>         Maximum number of dives to download (not allowed with -p/--fingerprint)\n"
 #endif
 	"\n"
 	"Supported output formats:\n"


### PR DESCRIPTION
This PR introduces a new `--count` option to the `dctool_download` utility, allowing users to specify the maximum number of the most recent dives to download. For example, `--count 1` will download only the latest dive, and `--count 5` will download the five most recent dives.

This feature provides a significant efficiency improvement, particularly when users are aware of the number of new dives they have made and wish to avoid a full download. The existing fingerprinting mechanism, while useful for automatically identifying previously imported dives, requires fetching all historical dives to build a complete set of fingerprints for comparison.

By utilizing the `--count` option, users can manually limit the download to only the expected number of new dives. This negates the need to download all previous dives solely for the purpose of checking for new fingerprinted dives, thereby reducing download time and resource consumption. This is especially beneficial for quick checks or when integrating with systems that only need to process the latest few dives.