### PR TITLE
Add Dockerfile for building and running the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stable-slim
+
+RUN apt-get update && apt-get install -y \
+    build-essential pkg-config libusb-1.0-0-dev \
+    autoconf automake libtool git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy local source
+COPY . .
+
+# build
+RUN autoreconf --install && ./configure && make
+
+WORKDIR /app/examples
+ENTRYPOINT ["./dctool"]

--- a/README
+++ b/README
@@ -45,13 +45,9 @@ To build the Docker image:
 
 To run a `libdivecomputer` command and interact with a dive computer (e.g., downloading data from a Suunto Cobra 3 via a serial device):
 
-  $ docker run --rm -it \
-    --device /dev/ttyUSB0 \
-    -v $(pwd):/out \
-    libdivecomputer \
-    download -t serial -f XML -o cobra3.xml suunto_cobra3
+  $ docker run --rm -it --device /dev/ttyUSB0 -v $(pwd):/out libdivecomputer -d "Suunto Cobra 3" download -t serial -f XML -o /out/cobra3.xml /dev/ttyUSB0
 
-*Note: Replace `/dev/ttyUSB0` with the actual path to your dive computer device (e.g., `/dev/ttyUSB0` for a serial device or `/dev/bus/usb/001/002` for a usb device). The `-v $(pwd):/out` mounts your current directory into the container, allowing output files (like `cobra3.xml`) to be saved to your host machine.*
+*Note: Replace `/dev/ttyUSB0` with the actual path to your dive computer device (e.g., `/dev/ttyUSB0` for a serial device or `/dev/bus/usb/001/002` for a USB device). The `-v $(pwd):/out` mounts your current directory into the container, allowing output files (like `cobra3.xml`) to be saved to your host machine.*
 
 Support
 =======

--- a/README
+++ b/README
@@ -34,6 +34,25 @@ To uninstall libdivecomputer again, run:
 
   $ make uninstall
 
+Docker Usage
+============
+
+This project provides a Dockerfile to create a consistent and isolated environment for both building and running the `libdivecomputer` tools.
+
+To build the Docker image:
+
+  $ docker build -t libdivecomputer .
+
+To run a `libdivecomputer` command and interact with a dive computer (e.g., downloading data from a Suunto Cobra 3 via a serial device):
+
+  $ docker run --rm -it \
+    --device /dev/ttyUSB0 \
+    -v $(pwd):/out \
+    libdivecomputer \
+    download -t serial -f XML -o cobra3.xml suunto_cobra3
+
+*Note: Replace `/dev/ttyUSB0` with the actual path to your dive computer device (e.g., `/dev/ttyUSB0` for a serial device or `/dev/bus/usb/001/002` for a usb device). The `-v $(pwd):/out` mounts your current directory into the container, allowing output files (like `cobra3.xml`) to be saved to your host machine.*
+
 Support
 =======
 


### PR DESCRIPTION
This PR introduces a Dockerfile to provide a consistent and isolated environment for both building and running the `libdivecomputer` tool.

This Dockerfile enables users to:
- Build the `libdivecomputer` tools within a containerized environment.
- Execute `libdivecomputer` commands, such as downloading dive computer data, in a reproducible runtime environment, including interaction with physical devices.

**Usage Examples:**

To build the Docker image:
```bash
docker build -t libdivecomputer .
```

To run a `libdivecomputer` command and interact with a USB device (e.g., downloading data from a Suunto Cobra 3):
```bash
docker run --rm -it \
  --device /dev/ttyUSB0 \
  -v $(pwd):/out \
  libdivecomputer \
  -d "Suunto Cobra 3" \
  download -t serial -f XML -o /out/cobra3.xml /dev/ttyUSB0
```
*Note: Replace `/dev/ttyUSB0` with the actual path to your dive computer device (e.g., `/dev/ttyUSB0` for a serial device or `/dev/bus/usb/001/002` for a usb device). The `-v $(pwd):/out` mounts your current directory into the container, allowing output files (like `cobra3.xml`) to be saved to your host machine.*

This change aims to streamline the development workflow, simplify testing, and provide a portable way to use `libdivecomputer` tools across different systems.