### PR TITLE
Resolve 109 compiler warnings

### DIFF
--- a/examples/common.c
+++ b/examples/common.c
@@ -19,6 +19,9 @@
  * MA 02110-1301 USA
  */
 
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -55,6 +58,26 @@ typedef struct transport_table_t {
 	const char *name;
 	dc_transport_t type;
 } transport_table_t;
+
+int
+dctool_parse_uint (const char *text, unsigned int *value)
+{
+	if (text == NULL || value == NULL)
+		return 0;
+	while (isspace ((unsigned char) *text))
+		text++;
+	if (*text == '-')
+		return 0;
+
+	char *end = NULL;
+	errno = 0;
+	unsigned long result = strtoul (text, &end, 0);
+	if (errno == ERANGE || end == text || *end != '\0' || result > UINT_MAX)
+		return 0;
+
+	*value = (unsigned int) result;
+	return 1;
+}
 
 static const backend_table_t g_backends[] = {
 	{"solution",    DC_FAMILY_SUUNTO_SOLUTION,     0},
@@ -486,7 +509,10 @@ dctool_irda_open (dc_iostream_t **out, dc_context_t *context, dc_descriptor_t *d
 
 	if (devname) {
 		// Use the address.
-		address = strtoul(devname, NULL, 0);
+		if (!dctool_parse_uint (devname, &address)) {
+			ERROR ("Invalid device address specified.");
+			return DC_STATUS_INVALIDARGS;
+		}
 	} else {
 		// Discover the device address.
 		dc_iterator_t *iterator = NULL;

--- a/examples/common.h
+++ b/examples/common.h
@@ -34,6 +34,9 @@ extern "C" {
 const char *
 dctool_errmsg (dc_status_t status);
 
+int
+dctool_parse_uint (const char *text, unsigned int *value);
+
 dc_family_t
 dctool_family_type (const char *name);
 

--- a/examples/dctool.c
+++ b/examples/dctool.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -94,11 +95,13 @@ void
 dctool_command_showhelp (const dctool_command_t *command)
 {
 	if (command == NULL) {
-		unsigned int maxlength = 0;
+		int maxlength = 0;
 		for (size_t i = 0; g_commands[i] != NULL; ++i) {
-			unsigned int length = strlen (g_commands[i]->name);
-			if (length > maxlength)
-				maxlength = length;
+			size_t length = strlen (g_commands[i]->name);
+			if (length > INT_MAX)
+				return;
+			if ((int) length > maxlength)
+				maxlength = (int) length;
 		}
 		printf (
 			"A simple command line interface for the libdivecomputer library\n"
@@ -211,7 +214,8 @@ main (int argc, char *argv[])
 			have_family = 1;
 			break;
 		case 'm':
-			model = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &model))
+				return EXIT_FAILURE;
 			have_model = 1;
 			break;
 		case 'l':

--- a/examples/dctool_download.c
+++ b/examples/dctool_download.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -134,9 +135,14 @@ event_cb (dc_device_t *device, dc_event_type_t event, const void *data, void *us
 			fingerprint = dctool_file_read (filename);
 
 			// Register the fingerprint data.
-			dc_device_set_fingerprint (device,
-				dc_buffer_get_data (fingerprint),
-				dc_buffer_get_size (fingerprint));
+			size_t size = dc_buffer_get_size (fingerprint);
+			if (size <= UINT_MAX) {
+				dc_device_set_fingerprint (device,
+					dc_buffer_get_data (fingerprint),
+					(unsigned int) size);
+			} else {
+				ERROR ("Cached fingerprint is too large.");
+			}
 
 			// Free the buffer again.
 			dc_buffer_free (fingerprint);
@@ -207,7 +213,13 @@ download (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tra
 	// Register the fingerprint data.
 	if (fingerprint) {
 		message ("Registering the fingerprint data.\n");
-		rc = dc_device_set_fingerprint (device, dc_buffer_get_data (fingerprint), dc_buffer_get_size (fingerprint));
+		size_t size = dc_buffer_get_size (fingerprint);
+		if (size > UINT_MAX) {
+			ERROR ("Fingerprint is too large.");
+			rc = DC_STATUS_INVALIDARGS;
+			goto cleanup;
+		}
+		rc = dc_device_set_fingerprint (device, dc_buffer_get_data (fingerprint), (unsigned int) size);
 		if (rc != DC_STATUS_SUCCESS) {
 			ERROR ("Error registering the fingerprint data.");
 			goto cleanup;
@@ -314,7 +326,8 @@ dctool_download_run (int argc, char *argv[], dc_context_t *context, dc_descripto
 				units = DCTOOL_UNITS_IMPERIAL;
 			break;
 		case 'l':
-			limit = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &limit))
+				return EXIT_FAILURE;
 			break;
 		default:
 			return EXIT_FAILURE;

--- a/examples/dctool_dump.c
+++ b/examples/dctool_dump.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -88,7 +89,13 @@ dump (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t transpo
 	// Register the fingerprint data.
 	if (fingerprint) {
 		message ("Registering the fingerprint data.\n");
-		rc = dc_device_set_fingerprint (device, dc_buffer_get_data (fingerprint), dc_buffer_get_size (fingerprint));
+		size_t size = dc_buffer_get_size (fingerprint);
+		if (size > UINT_MAX) {
+			ERROR ("Fingerprint is too large.");
+			rc = DC_STATUS_INVALIDARGS;
+			goto cleanup;
+		}
+		rc = dc_device_set_fingerprint (device, dc_buffer_get_data (fingerprint), (unsigned int) size);
 		if (rc != DC_STATUS_SUCCESS) {
 			ERROR ("Error registering the fingerprint data.");
 			goto cleanup;

--- a/examples/dctool_parse.c
+++ b/examples/dctool_parse.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -50,7 +51,10 @@ parse (dc_buffer_t *buffer, dc_context_t *context, dc_descriptor_t *descriptor, 
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	dc_parser_t *parser = NULL;
 	unsigned char *data = dc_buffer_get_data (buffer);
-	unsigned int size = dc_buffer_get_size (buffer);
+	size_t buffer_size = dc_buffer_get_size (buffer);
+	if (buffer_size > UINT_MAX)
+		return DC_STATUS_INVALIDARGS;
+	unsigned int size = (unsigned int) buffer_size;
 
 	// Create the parser.
 	message ("Creating the parser.\n");
@@ -121,7 +125,8 @@ dctool_parse_run (int argc, char *argv[], dc_context_t *context, dc_descriptor_t
 			filename = optarg;
 			break;
 		case 'd':
-			devtime = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &devtime))
+				return EXIT_FAILURE;
 			break;
 		case 's':
 			systime = strtoll (optarg, NULL, 0);

--- a/examples/dctool_read.c
+++ b/examples/dctool_read.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
@@ -86,7 +87,12 @@ doread (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t trans
 
 	// Read data from the internal memory.
 	message ("Reading data from the internal memory.\n");
-	rc = dc_device_read (device, address, dc_buffer_get_data (buffer), dc_buffer_get_size (buffer));
+	size_t size = dc_buffer_get_size (buffer);
+	if (size > UINT_MAX) {
+		rc = DC_STATUS_INVALIDARGS;
+		goto cleanup;
+	}
+	rc = dc_device_read (device, address, dc_buffer_get_data (buffer), (unsigned int) size);
 	if (rc != DC_STATUS_SUCCESS) {
 		ERROR ("Error reading from the internal memory.");
 		goto cleanup;
@@ -136,11 +142,13 @@ dctool_read_run (int argc, char *argv[], dc_context_t *context, dc_descriptor_t 
 			transport = dctool_transport_type (optarg);
 			break;
 		case 'a':
-			address = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &address))
+				return EXIT_FAILURE;
 			have_address = 1;
 			break;
 		case 'c':
-			count = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &count))
+				return EXIT_FAILURE;
 			have_count = 1;
 			break;
 		case 'o':

--- a/examples/dctool_write.c
+++ b/examples/dctool_write.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
@@ -86,7 +87,12 @@ dowrite (dc_context_t *context, dc_descriptor_t *descriptor, dc_transport_t tran
 
 	// Write data to the internal memory.
 	message ("Writing data to the internal memory.\n");
-	rc = dc_device_write (device, address, dc_buffer_get_data (buffer), dc_buffer_get_size (buffer));
+	size_t size = dc_buffer_get_size (buffer);
+	if (size > UINT_MAX) {
+		rc = DC_STATUS_INVALIDARGS;
+		goto cleanup;
+	}
+	rc = dc_device_write (device, address, dc_buffer_get_data (buffer), (unsigned int) size);
 	if (rc != DC_STATUS_SUCCESS) {
 		ERROR ("Error writing to the internal memory.");
 		goto cleanup;
@@ -136,11 +142,13 @@ dctool_write_run (int argc, char *argv[], dc_context_t *context, dc_descriptor_t
 			transport = dctool_transport_type (optarg);
 			break;
 		case 'a':
-			address = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &address))
+				return EXIT_FAILURE;
 			have_address = 1;
 			break;
 		case 'c':
-			count = strtoul (optarg, NULL, 0);
+			if (!dctool_parse_uint (optarg, &count))
+				return EXIT_FAILURE;
 			have_count = 1;
 			break;
 		case 'i':

--- a/examples/output_raw.c
+++ b/examples/output_raw.c
@@ -19,6 +19,7 @@
  * MA 02110-1301 USA
  */
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -47,7 +48,7 @@ mktemplate_fingerprint (char *buffer, size_t size, const unsigned char fingerpri
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-	if (size < 2 * fsize + 1)
+	if (fsize > INT_MAX / 2 || size < 2 * fsize + 1)
 		return -1;
 
 	for (size_t i = 0; i < fsize; ++i) {
@@ -63,7 +64,7 @@ mktemplate_fingerprint (char *buffer, size_t size, const unsigned char fingerpri
 	// Null-terminate the string.
 	buffer[fsize * 2] = 0;
 
-	return fsize * 2;
+	return (int) (fsize * 2);
 }
 
 static int
@@ -83,7 +84,9 @@ mktemplate_datetime (char *buffer, size_t size, dc_parser_t *parser)
 	if (n < 0 || (size_t) n >= size)
 		return -1;
 
-	return n;
+	if (n > INT_MAX)
+		return -1;
+	return (int) n;
 }
 
 static int
@@ -151,7 +154,9 @@ mktemplate (char *buffer, size_t size, const char *format, dc_parser_t *parser, 
 		return -1;
 	buffer[n] = 0;
 
-	return n;
+	if (n > INT_MAX)
+		return -1;
+	return (int) n;
 }
 
 dctool_output_t *

--- a/examples/output_xml.c
+++ b/examples/output_xml.c
@@ -429,7 +429,7 @@ dctool_xml_output_write (dctool_output_t *abstract, dc_parser_t *parser, const u
 
 	// Parse the deco model.
 	message ("Parsing the deco model.\n");
-	dc_decomodel_t decomodel = {DC_DECOMODEL_NONE};
+	dc_decomodel_t decomodel = {.type = DC_DECOMODEL_NONE};
 	status = dc_parser_get_field (parser, DC_FIELD_DECOMODEL, 0, &decomodel);
 	if (status != DC_STATUS_SUCCESS && status != DC_STATUS_UNSUPPORTED) {
 		ERROR ("Error parsing the deco model.");

--- a/include/libdivecomputer/device.h
+++ b/include/libdivecomputer/device.h
@@ -44,8 +44,8 @@ typedef enum dc_event_type_t {
 typedef struct dc_device_t dc_device_t;
 
 typedef struct dc_event_progress_t {
-	unsigned int current;
-	unsigned int maximum;
+	size_t current;
+	size_t maximum;
 } dc_event_progress_t;
 
 typedef struct dc_event_devinfo_t {
@@ -61,14 +61,14 @@ typedef struct dc_event_clock_t {
 
 typedef struct dc_event_vendor_t {
 	const unsigned char *data;
-	unsigned int size;
+	size_t size;
 } dc_event_vendor_t;
 
 typedef int (*dc_cancel_callback_t) (void *userdata);
 
 typedef void (*dc_event_callback_t) (dc_device_t *device, dc_event_type_t event, const void *data, void *userdata);
 
-typedef int (*dc_dive_callback_t) (const unsigned char *data, unsigned int size, const unsigned char *fingerprint, unsigned int fsize, void *userdata);
+typedef int (*dc_dive_callback_t) (const unsigned char *data, size_t size, const unsigned char *fingerprint, size_t fsize, void *userdata);
 
 dc_status_t
 dc_device_open (dc_device_t **out, dc_context_t *context, dc_descriptor_t *descriptor, dc_iostream_t *iostream);

--- a/include/libdivecomputer/device.h
+++ b/include/libdivecomputer/device.h
@@ -44,8 +44,8 @@ typedef enum dc_event_type_t {
 typedef struct dc_device_t dc_device_t;
 
 typedef struct dc_event_progress_t {
-	size_t current;
-	size_t maximum;
+	unsigned int current;
+	unsigned int maximum;
 } dc_event_progress_t;
 
 typedef struct dc_event_devinfo_t {
@@ -61,14 +61,14 @@ typedef struct dc_event_clock_t {
 
 typedef struct dc_event_vendor_t {
 	const unsigned char *data;
-	size_t size;
+	unsigned int size;
 } dc_event_vendor_t;
 
 typedef int (*dc_cancel_callback_t) (void *userdata);
 
 typedef void (*dc_event_callback_t) (dc_device_t *device, dc_event_type_t event, const void *data, void *userdata);
 
-typedef int (*dc_dive_callback_t) (const unsigned char *data, size_t size, const unsigned char *fingerprint, size_t fsize, void *userdata);
+typedef int (*dc_dive_callback_t) (const unsigned char *data, unsigned int size, const unsigned char *fingerprint, unsigned int fsize, void *userdata);
 
 dc_status_t
 dc_device_open (dc_device_t **out, dc_context_t *context, dc_descriptor_t *descriptor, dc_iostream_t *iostream);

--- a/src/array.c
+++ b/src/array.c
@@ -24,9 +24,9 @@
 #include "array.h"
 
 void
-array_reverse_bytes (unsigned char data[], unsigned int size)
+array_reverse_bytes (unsigned char data[], size_t size)
 {
-	for (unsigned int i = 0; i < size / 2; ++i) {
+	for (size_t i = 0; i < size / 2; ++i) {
 		unsigned char hlp = data[i];
 		data[i] = data[size - 1 - i];
 		data[size - 1 - i] = hlp;
@@ -35,9 +35,9 @@ array_reverse_bytes (unsigned char data[], unsigned int size)
 
 
 void
-array_reverse_bits (unsigned char data[], unsigned int size)
+array_reverse_bits (unsigned char data[], size_t size)
 {
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		unsigned char j = 0;
 		j  = (data[i] & 0x01) << 7;
 		j += (data[i] & 0x02) << 5;
@@ -52,18 +52,18 @@ array_reverse_bits (unsigned char data[], unsigned int size)
 }
 
 void
-array_reverse_nibbles (unsigned char data[], unsigned int size)
+array_reverse_nibbles (unsigned char data[], size_t size)
 {
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		unsigned char tmp = data[i];
 		data[i] = ((tmp & 0xF0) >> 4) | ((tmp & 0x0F) << 4);
 	}
 }
 
 int
-array_isequal (const unsigned char data[], unsigned int size, unsigned char value)
+array_isequal (const unsigned char data[], size_t size, unsigned char value)
 {
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		if (data[i] != value)
 			return 0;
 	}
@@ -73,8 +73,8 @@ array_isequal (const unsigned char data[], unsigned int size, unsigned char valu
 
 
 const unsigned char *
-array_search_forward (const unsigned char *data, unsigned int size,
-                      const unsigned char *marker, unsigned int msize)
+array_search_forward (const unsigned char *data, size_t size,
+					  const unsigned char *marker, size_t msize)
 {
 	while (size >= msize) {
 		if (memcmp (data, marker, msize) == 0)
@@ -87,8 +87,8 @@ array_search_forward (const unsigned char *data, unsigned int size,
 
 
 const unsigned char *
-array_search_backward (const unsigned char *data, unsigned int size,
-                       const unsigned char *marker, unsigned int msize)
+array_search_backward (const unsigned char *data, size_t size,
+					   const unsigned char *marker, size_t msize)
 {
 	data += size;
 	while (size >= msize) {
@@ -102,7 +102,7 @@ array_search_backward (const unsigned char *data, unsigned int size,
 
 
 int
-array_convert_bin2hex (const unsigned char input[], unsigned int isize, unsigned char output[], unsigned int osize)
+array_convert_bin2hex (const unsigned char input[], size_t isize, unsigned char output[], size_t osize)
 {
 	if (osize != 2 * isize)
 		return -1;
@@ -111,7 +111,7 @@ array_convert_bin2hex (const unsigned char input[], unsigned int isize, unsigned
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-	for (unsigned int i = 0; i < isize; ++i) {
+	for (size_t i = 0; i < isize; ++i) {
 		// Set the most-significant nibble.
 		unsigned char msn = (input[i] >> 4) & 0x0F;
 		output[i * 2 + 0] = ascii[msn];
@@ -126,12 +126,12 @@ array_convert_bin2hex (const unsigned char input[], unsigned int isize, unsigned
 
 
 int
-array_convert_hex2bin (const unsigned char input[], unsigned int isize, unsigned char output[], unsigned int osize)
+array_convert_hex2bin (const unsigned char input[], size_t isize, unsigned char output[], size_t osize)
 {
 	if (isize != 2 * osize)
 		return -1;
 
-	for (unsigned int i = 0; i < osize; ++i) {
+	for (size_t i = 0; i < osize; ++i) {
 		unsigned char value = 0;
 		for (unsigned int j = 0; j < 2; ++j) {
 			unsigned char number = 0;
@@ -155,10 +155,10 @@ array_convert_hex2bin (const unsigned char input[], unsigned int isize, unsigned
 }
 
 unsigned int
-array_convert_str2num (const unsigned char data[], unsigned int size)
+array_convert_str2num (const unsigned char data[], size_t size)
 {
 	unsigned int value = 0;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		if (data[i] < '0' || data[i] > '9')
 			break;
 		value *= 10;
@@ -169,10 +169,10 @@ array_convert_str2num (const unsigned char data[], unsigned int size)
 }
 
 unsigned int
-array_convert_bin2dec (const unsigned char data[], unsigned int size)
+array_convert_bin2dec (const unsigned char data[], size_t size)
 {
 	unsigned int value = 0;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		value *= 100;
 		value += data[i];
 	}
@@ -181,10 +181,10 @@ array_convert_bin2dec (const unsigned char data[], unsigned int size)
 }
 
 unsigned int
-array_convert_bcd2dec (const unsigned char data[], unsigned int size)
+array_convert_bcd2dec (const unsigned char data[], size_t size)
 {
 	unsigned int value = 0;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		value *= 100;
 		value += bcd2dec(data[i]);
 	}

--- a/src/array.h
+++ b/src/array.h
@@ -30,39 +30,39 @@ extern "C" {
 #endif /* __cplusplus */
 
 void
-array_reverse_bytes (unsigned char data[], unsigned int size);
+array_reverse_bytes (unsigned char data[], size_t size);
 
 void
-array_reverse_bits (unsigned char data[], unsigned int size);
+array_reverse_bits (unsigned char data[], size_t size);
 
 void
-array_reverse_nibbles (unsigned char data[], unsigned int size);
+array_reverse_nibbles (unsigned char data[], size_t size);
 
 int
-array_isequal (const unsigned char data[], unsigned int size, unsigned char value);
+array_isequal (const unsigned char data[], size_t size, unsigned char value);
 
 const unsigned char *
-array_search_forward (const unsigned char *data, unsigned int size,
-                      const unsigned char *marker, unsigned int msize);
+array_search_forward (const unsigned char *data, size_t size,
+					  const unsigned char *marker, size_t msize);
 
 const unsigned char *
-array_search_backward (const unsigned char *data, unsigned int size,
-                       const unsigned char *marker, unsigned int msize);
+array_search_backward (const unsigned char *data, size_t size,
+					   const unsigned char *marker, size_t msize);
 
 int
-array_convert_bin2hex (const unsigned char input[], unsigned int isize, unsigned char output[], unsigned int osize);
+array_convert_bin2hex (const unsigned char input[], size_t isize, unsigned char output[], size_t osize);
 
 int
-array_convert_hex2bin (const unsigned char input[], unsigned int isize, unsigned char output[], unsigned int osize);
+array_convert_hex2bin (const unsigned char input[], size_t isize, unsigned char output[], size_t osize);
 
 unsigned int
-array_convert_str2num (const unsigned char data[], unsigned int size);
+array_convert_str2num (const unsigned char data[], size_t size);
 
 unsigned int
-array_convert_bin2dec (const unsigned char data[], unsigned int size);
+array_convert_bin2dec (const unsigned char data[], size_t size);
 
 unsigned int
-array_convert_bcd2dec (const unsigned char data[], unsigned int size);
+array_convert_bcd2dec (const unsigned char data[], size_t size);
 
 unsigned int
 array_uint_be (const unsigned char data[], unsigned int n);

--- a/src/atomics_cobalt.c
+++ b/src/atomics_cobalt.c
@@ -344,7 +344,7 @@ atomics_cobalt_device_foreach (dc_device_t *abstract, dc_dive_callback_t callbac
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	while ((rc = atomics_cobalt_read_dive (abstract, buffer, (ndives == 0), &progress)) == DC_STATUS_SUCCESS) {
 		unsigned char *data = dc_buffer_get_data (buffer);
-		unsigned int size = dc_buffer_get_size (buffer);
+		size_t size = dc_buffer_get_size (buffer);
 
 		if (size == 0) {
 			dc_buffer_free (buffer);
@@ -352,7 +352,7 @@ atomics_cobalt_device_foreach (dc_device_t *abstract, dc_dive_callback_t callbac
 		}
 
 		if (size < SZ_HEADER) {
-			ERROR (abstract->context, "Dive header is too small (%u).", size);
+			ERROR (abstract->context, "Dive header is too small (" DC_PRINTF_SIZE ").", size);
 			dc_buffer_free (buffer);
 			return DC_STATUS_DATAFORMAT;
 		}

--- a/src/atomics_cobalt.c
+++ b/src/atomics_cobalt.c
@@ -356,13 +356,18 @@ atomics_cobalt_device_foreach (dc_device_t *abstract, dc_dive_callback_t callbac
 			dc_buffer_free (buffer);
 			return DC_STATUS_DATAFORMAT;
 		}
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			dc_buffer_free (buffer);
+			return DC_STATUS_DATAFORMAT;
+		}
 
 		if (memcmp (data + FP_OFFSET, device->fingerprint, sizeof (device->fingerprint)) == 0) {
 			dc_buffer_free (buffer);
 			return DC_STATUS_SUCCESS;
 		}
 
-		if (callback && !callback (data, size, data + FP_OFFSET, sizeof (device->fingerprint), userdata)) {
+		if (callback && !callback (data, (unsigned int) size, data + FP_OFFSET, sizeof (device->fingerprint), userdata)) {
 			dc_buffer_free (buffer);
 			return DC_STATUS_SUCCESS;
 		}

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -23,10 +23,10 @@
 
 
 unsigned char
-checksum_add_uint4 (const unsigned char data[], unsigned int size, unsigned char init)
+checksum_add_uint4 (const unsigned char data[], size_t size, unsigned char init)
 {
 	unsigned char crc = init;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		crc += (data[i] & 0xF0) >> 4;
 		crc += (data[i] & 0x0F);
 	}
@@ -36,10 +36,10 @@ checksum_add_uint4 (const unsigned char data[], unsigned int size, unsigned char
 
 
 unsigned char
-checksum_add_uint8 (const unsigned char data[], unsigned int size, unsigned char init)
+checksum_add_uint8 (const unsigned char data[], size_t size, unsigned char init)
 {
 	unsigned char crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc += data[i];
 
 	return crc;
@@ -47,10 +47,10 @@ checksum_add_uint8 (const unsigned char data[], unsigned int size, unsigned char
 
 
 unsigned short
-checksum_add_uint16 (const unsigned char data[], unsigned int size, unsigned short init)
+checksum_add_uint16 (const unsigned char data[], size_t size, unsigned short init)
 {
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc += data[i];
 
 	return crc;
@@ -58,10 +58,10 @@ checksum_add_uint16 (const unsigned char data[], unsigned int size, unsigned sho
 
 
 unsigned char
-checksum_xor_uint8 (const unsigned char data[], unsigned int size, unsigned char init)
+checksum_xor_uint8 (const unsigned char data[], size_t size, unsigned char init)
 {
 	unsigned char crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc ^= data[i];
 
 	return crc;
@@ -73,7 +73,7 @@ checksum_xor_uint8 (const unsigned char data[], unsigned int size, unsigned char
  * RefOut: False
  */
 unsigned char
-checksum_crc8 (const unsigned char data[], unsigned int size, unsigned char init, unsigned char xorout)
+checksum_crc8 (const unsigned char data[], size_t size, unsigned char init, unsigned char xorout)
 {
 	static const unsigned char crc_table[] = {
 		0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,
@@ -111,7 +111,7 @@ checksum_crc8 (const unsigned char data[], unsigned int size, unsigned char init
 	};
 
 	unsigned char crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = crc_table[data[i] ^ crc];
 
 	return crc ^ xorout;
@@ -123,7 +123,7 @@ checksum_crc8 (const unsigned char data[], unsigned int size, unsigned char init
  * RefOut: False
  */
 unsigned short
-checksum_crc16_ccitt (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout)
+checksum_crc16_ccitt (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout)
 {
 	static const unsigned short crc_ccitt_table[] = {
 		0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
@@ -161,7 +161,7 @@ checksum_crc16_ccitt (const unsigned char data[], unsigned int size, unsigned sh
 	};
 
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = (crc << 8) ^ crc_ccitt_table[(crc >> 8) ^ data[i]];
 
 	return crc ^ xorout;
@@ -174,7 +174,7 @@ checksum_crc16_ccitt (const unsigned char data[], unsigned int size, unsigned sh
  * RefOut: True
  */
 unsigned short
-checksum_crc16r_ccitt (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout)
+checksum_crc16r_ccitt (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout)
 {
 	static const unsigned short crc_ccitt_table[] = {
 		0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,
@@ -212,7 +212,7 @@ checksum_crc16r_ccitt (const unsigned char data[], unsigned int size, unsigned s
 	};
 
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = (crc >> 8) ^ crc_ccitt_table[(crc ^ data[i]) & 0xff];
 
 	return crc ^ xorout;
@@ -224,7 +224,7 @@ checksum_crc16r_ccitt (const unsigned char data[], unsigned int size, unsigned s
  * RefOut: False
  */
 unsigned short
-checksum_crc16_ansi (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout)
+checksum_crc16_ansi (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout)
 {
 	static const unsigned short crc_ccitt_table[] = {
 		0x0000, 0x8005, 0x800f, 0x000a, 0x801b, 0x001e, 0x0014, 0x8011,
@@ -262,7 +262,7 @@ checksum_crc16_ansi (const unsigned char data[], unsigned int size, unsigned sho
 	};
 
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = (crc << 8) ^ crc_ccitt_table[(crc >> 8) ^ data[i]];
 
 	return crc ^ xorout;
@@ -274,7 +274,7 @@ checksum_crc16_ansi (const unsigned char data[], unsigned int size, unsigned sho
  * RefOut: True
  */
 unsigned short
-checksum_crc16r_ansi (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout)
+checksum_crc16r_ansi (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout)
 {
 	static const unsigned short crc_ccitt_table[] = {
 		0x0000, 0xc0c1, 0xc181, 0x0140, 0xc301, 0x03c0, 0x0280, 0xc241,
@@ -312,7 +312,7 @@ checksum_crc16r_ansi (const unsigned char data[], unsigned int size, unsigned sh
 	};
 
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = (crc >> 8) ^ crc_ccitt_table[(crc ^ data[i]) & 0xff];
 
 	return crc ^ xorout;
@@ -327,7 +327,7 @@ checksum_crc16r_ansi (const unsigned char data[], unsigned int size, unsigned sh
  * RefOut: True
  */
 unsigned int
-checksum_crc32r (const unsigned char data[], unsigned int size)
+checksum_crc32r (const unsigned char data[], size_t size)
 {
 	static const unsigned int crc_table[] = {
 		0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
@@ -365,7 +365,7 @@ checksum_crc32r (const unsigned char data[], unsigned int size)
 	};
 
 	unsigned int crc = 0xffffffff;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = crc_table[(crc ^ data[i]) & 0xff] ^ (crc >> 8);
 
 	return crc ^ 0xffffffff;
@@ -380,7 +380,7 @@ checksum_crc32r (const unsigned char data[], unsigned int size)
  * RefOut: False
  */
 unsigned int
-checksum_crc32 (const unsigned char data[], unsigned int size)
+checksum_crc32 (const unsigned char data[], size_t size)
 {
 	static const unsigned int crc_table[] = {
 		0x00000000, 0x04C11DB7, 0x09823B6E, 0x0D4326D9, 0x130476DC, 0x17C56B6B, 0x1A864DB2, 0x1E475005,
@@ -418,7 +418,7 @@ checksum_crc32 (const unsigned char data[], unsigned int size)
 	};
 
 	unsigned int crc = 0xffffffff;
-	for (unsigned int i = 0; i < size; ++i)
+	for (size_t i = 0; i < size; ++i)
 		crc = crc_table[((crc >> 24) ^ data[i]) & 0xFF] ^ (crc << 8);
 
 	return crc ^ 0xffffffff;

--- a/src/checksum.h
+++ b/src/checksum.h
@@ -22,42 +22,44 @@
 #ifndef CHECKSUM_H
 #define CHECKSUM_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
 unsigned char
-checksum_add_uint4 (const unsigned char data[], unsigned int size, unsigned char init);
+checksum_add_uint4 (const unsigned char data[], size_t size, unsigned char init);
 
 unsigned char
-checksum_add_uint8 (const unsigned char data[], unsigned int size, unsigned char init);
+checksum_add_uint8 (const unsigned char data[], size_t size, unsigned char init);
 
 unsigned short
-checksum_add_uint16 (const unsigned char data[], unsigned int size, unsigned short init);
+checksum_add_uint16 (const unsigned char data[], size_t size, unsigned short init);
 
 unsigned char
-checksum_xor_uint8 (const unsigned char data[], unsigned int size, unsigned char init);
+checksum_xor_uint8 (const unsigned char data[], size_t size, unsigned char init);
 
 unsigned char
-checksum_crc8 (const unsigned char data[], unsigned int size, unsigned char init, unsigned char xorout);
+checksum_crc8 (const unsigned char data[], size_t size, unsigned char init, unsigned char xorout);
 
 unsigned short
-checksum_crc16_ccitt (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout);
+checksum_crc16_ccitt (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout);
 
 unsigned short
-checksum_crc16r_ccitt (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout);
+checksum_crc16r_ccitt (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout);
 
 unsigned short
-checksum_crc16_ansi (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout);
+checksum_crc16_ansi (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout);
 
 unsigned short
-checksum_crc16r_ansi (const unsigned char data[], unsigned int size, unsigned short init, unsigned short xorout);
+checksum_crc16r_ansi (const unsigned char data[], size_t size, unsigned short init, unsigned short xorout);
 
 unsigned int
-checksum_crc32r (const unsigned char data[], unsigned int size);
+checksum_crc32r (const unsigned char data[], size_t size);
 
 unsigned int
-checksum_crc32 (const unsigned char data[], unsigned int size);
+checksum_crc32 (const unsigned char data[], size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/citizen_aqualand.c
+++ b/src/citizen_aqualand.c
@@ -200,10 +200,10 @@ citizen_aqualand_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 	}
 
 	unsigned char *data = dc_buffer_get_data (buffer);
-	unsigned int   size = dc_buffer_get_size (buffer);
+	size_t         size = dc_buffer_get_size (buffer);
 
 	if (size < SZ_HEADER) {
-		ERROR (abstract->context, "Dive header is too small (%u).", size);
+		ERROR (abstract->context, "Dive header is too small (" DC_PRINTF_SIZE ").", size);
 		dc_buffer_free (buffer);
 		return DC_STATUS_DATAFORMAT;
 	}

--- a/src/citizen_aqualand.c
+++ b/src/citizen_aqualand.c
@@ -207,9 +207,14 @@ citizen_aqualand_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 		dc_buffer_free (buffer);
 		return DC_STATUS_DATAFORMAT;
 	}
+	if (size > UINT_MAX) {
+		ERROR (abstract->context, "Dive data is too large.");
+		dc_buffer_free (buffer);
+		return DC_STATUS_DATAFORMAT;
+	}
 
 	if (callback && memcmp (data + 0x05, device->fingerprint, sizeof (device->fingerprint)) != 0) {
-		callback (data, size, data + 0x05, sizeof (device->fingerprint), userdata);
+		callback (data, (unsigned int) size, data + 0x05, sizeof (device->fingerprint), userdata);
 	}
 
 	dc_buffer_free (buffer);

--- a/src/cochran_commander.c
+++ b/src/cochran_commander.c
@@ -541,7 +541,7 @@ static dc_status_t
 cochran_commander_read_retry (cochran_commander_device_t *device, dc_event_progress_t *progress, unsigned int address, unsigned char data[], unsigned int size)
 {
 	// Save the state of the progress events.
-	unsigned int saved = 0;
+	size_t saved = 0;
 	if (progress) {
 		saved = progress->current;
 	}

--- a/src/cochran_commander.c
+++ b/src/cochran_commander.c
@@ -541,7 +541,7 @@ static dc_status_t
 cochran_commander_read_retry (cochran_commander_device_t *device, dc_event_progress_t *progress, unsigned int address, unsigned char data[], unsigned int size)
 {
 	// Save the state of the progress events.
-	size_t saved = 0;
+	unsigned int saved = 0;
 	if (progress) {
 		saved = progress->current;
 	}

--- a/src/context-private.h
+++ b/src/context-private.h
@@ -65,7 +65,7 @@ dc_status_t
 dc_context_syserror (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, int errcode);
 
 dc_status_t
-dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *prefix, const unsigned char data[], unsigned int size);
+dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *prefix, const unsigned char data[], size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/context.c
+++ b/src/context.c
@@ -245,7 +245,7 @@ dc_context_syserror (dc_context_t *context, dc_loglevel_t loglevel, const char *
 }
 
 dc_status_t
-dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *prefix, const unsigned char data[], unsigned int size)
+dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *prefix, const unsigned char data[], size_t size)
 {
 #ifdef ENABLE_LOGGING
 	int n;
@@ -261,7 +261,7 @@ dc_context_hexdump (dc_context_t *context, dc_loglevel_t loglevel, const char *f
 	if (context->logfunc == NULL)
 		return DC_STATUS_SUCCESS;
 
-	n = dc_platform_snprintf (context->msg, sizeof (context->msg), "%s: size=%u, data=", prefix, size);
+	n = dc_platform_snprintf (context->msg, sizeof (context->msg), "%s: size=" DC_PRINTF_SIZE ", data=", prefix, size);
 
 	if (n >= 0) {
 		n = l_hexdump (context->msg + n, sizeof (context->msg) - n, data, size);

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -217,7 +217,7 @@ cressi_goa_device_download (cressi_goa_device_t *device, dc_buffer_t *buffer, dc
 	dc_transport_t transport = dc_iostream_get_transport (device->iostream);
 
 	const unsigned char ack[] = {ACK};
-	const size_t initial = progress ? progress->current : 0;
+	const unsigned int initial = progress ? progress->current : 0;
 
 	// Erase the contents of the buffer.
 	if (!dc_buffer_clear (buffer)) {
@@ -524,7 +524,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 
 	HEXDUMP (abstract->context, DC_LOGLEVEL_DEBUG, "Version", id_data, id_size);
 
-	if (id_size < 9) {
+	if (id_size < 9 || id_size > UCHAR_MAX) {
 		ERROR (abstract->context, "Unexpected version length (" DC_PRINTF_SIZE ").", id_size);
 		status = DC_STATUS_DATAFORMAT;
 		goto error_free_id;
@@ -564,7 +564,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 	// Emit a vendor event.
 	dc_event_vendor_t vendor;
 	vendor.data = id_data;
-	vendor.size = id_size;
+	vendor.size = (unsigned int) id_size;
 	device_event_emit (abstract, DC_EVENT_VENDOR, &vendor);
 
 	// Emit a device info event.
@@ -668,7 +668,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 		// are prepended to the dive data, along with a small header containing
 		// their size.
 		const unsigned char header[] = {
-			id_size,
+			(unsigned char) id_size,
 			conf->logbook_len,
 		};
 		size_t headersize = sizeof(header) + id_size + conf->logbook_len;
@@ -682,8 +682,13 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 
 		dive_data = dc_buffer_get_data (dive);
 		dive_size = dc_buffer_get_size (dive);
+		if (dive_size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free_dive;
+		}
 
-		if (callback && !callback(dive_data, dive_size, dive_data + headersize + conf->dive_fp_offset, sizeof(device->fingerprint), userdata))
+		if (callback && !callback(dive_data, (unsigned int) dive_size, dive_data + headersize + conf->dive_fp_offset, sizeof(device->fingerprint), userdata))
 			break;
 	}
 

--- a/src/cressi_goa.c
+++ b/src/cressi_goa.c
@@ -217,7 +217,7 @@ cressi_goa_device_download (cressi_goa_device_t *device, dc_buffer_t *buffer, dc
 	dc_transport_t transport = dc_iostream_get_transport (device->iostream);
 
 	const unsigned char ack[] = {ACK};
-	const unsigned int initial = progress ? progress->current : 0;
+	const size_t initial = progress ? progress->current : 0;
 
 	// Erase the contents of the buffer.
 	if (!dc_buffer_clear (buffer)) {
@@ -599,7 +599,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 
 	// Count the number of dives.
 	unsigned int count = 0;
-	unsigned int offset = logbook_size;
+	size_t offset = logbook_size;
 	while (offset >= conf->logbook_len) {
 		// Move to the start of the logbook entry.
 		offset -= conf->logbook_len;
@@ -671,7 +671,7 @@ cressi_goa_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, v
 			id_size,
 			conf->logbook_len,
 		};
-		unsigned int headersize = sizeof(header) + id_size + conf->logbook_len;
+		size_t headersize = sizeof(header) + id_size + conf->logbook_len;
 		if (!dc_buffer_prepend(dive, logbook_data + offset, conf->logbook_len) ||
 			!dc_buffer_prepend(dive, id_data, id_size) ||
 			!dc_buffer_prepend(dive, header, sizeof(header))) {

--- a/src/cressi_leonardo.c
+++ b/src/cressi_leonardo.c
@@ -70,7 +70,7 @@ static const dc_device_vtable_t cressi_leonardo_device_vtable = {
 };
 
 static dc_status_t
-cressi_leonardo_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+cressi_leonardo_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 static void
 cressi_leonardo_make_ascii (const unsigned char raw[], unsigned int rsize, unsigned char ascii[], unsigned int asize)
@@ -252,10 +252,10 @@ cressi_leonardo_device_read (dc_device_t *abstract, unsigned int address, unsign
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	cressi_leonardo_device_t *device = (cressi_leonardo_device_t *) abstract;
 
-	unsigned int nbytes = 0;
+	size_t nbytes = 0;
 	while (nbytes < size) {
 		// Calculate the packet size.
-		unsigned int len = size - nbytes;
+		size_t len = size - nbytes;
 		if (len > PACKETSIZE)
 			len = PACKETSIZE;
 
@@ -272,7 +272,7 @@ cressi_leonardo_device_read (dc_device_t *abstract, unsigned int address, unsign
 
 		// Send the command and receive the answer.
 		unsigned char answer[2 * (PACKETSIZE + 3)] = {0};
-		rc = cressi_leonardo_transfer (device, command, sizeof (command), answer, 2 * (len + 3));
+		rc = cressi_leonardo_transfer (device, command, sizeof (command), answer, 2 * (unsigned int) (len + 3));
 		if (rc != DC_STATUS_SUCCESS)
 			return rc;
 
@@ -332,7 +332,7 @@ cressi_leonardo_device_dump (dc_device_t *abstract, dc_buffer_t *buffer)
 	unsigned int nbytes = 0;
 	while (nbytes < SZ_MEMORY) {
 		// Set the minimum packet size.
-		unsigned int len = 1024;
+		size_t len = 1024;
 
 		// Increase the packet size if more data is immediately available.
 		size_t available = 0;
@@ -410,7 +410,7 @@ cressi_leonardo_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 }
 
 static dc_status_t
-cressi_leonardo_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+cressi_leonardo_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	cressi_leonardo_device_t *device = (cressi_leonardo_device_t *) abstract;
 	dc_context_t *context = (abstract ? abstract->context : NULL);

--- a/src/datetime.c
+++ b/src/datetime.c
@@ -120,14 +120,18 @@ dc_datetime_localtime (dc_datetime_t *result,
 		return NULL;
 
 #ifdef HAVE_STRUCT_TM_TM_GMTOFF
-	offset = tm.tm_gmtoff;
+	if (tm.tm_gmtoff < INT_MIN || tm.tm_gmtoff > INT_MAX)
+		return NULL;
+	offset = (int) tm.tm_gmtoff;
 #else
 	struct tm tmp = tm;
 	time_t t_local = dc_timegm (&tmp);
 	if (t_local == (time_t) -1)
 		return NULL;
 
-	offset = t_local - t;
+	if (t_local - t < INT_MIN || t_local - t > INT_MAX)
+		return NULL;
+	offset = (int) (t_local - t);
 #endif
 
 	if (result) {

--- a/src/deepblu_cosmiq.c
+++ b/src/deepblu_cosmiq.c
@@ -297,7 +297,7 @@ deepblu_cosmiq_recv_bulk (deepblu_cosmiq_device_t *device, dc_event_progress_t *
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
 
-	const size_t initial = progress ? progress->current : 0;
+	const unsigned int initial = progress ? progress->current : 0;
 
 	size_t nbytes = 0;
 	while (nbytes < size) {
@@ -310,7 +310,7 @@ deepblu_cosmiq_recv_bulk (deepblu_cosmiq_device_t *device, dc_event_progress_t *
 
 		// Update and emit a progress event.
 		if (progress) {
-			progress->current = initial + STEP(nbytes, size);
+			progress->current = initial + (unsigned int) STEP(nbytes, size);
 			device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
 		}
 	}

--- a/src/deepblu_cosmiq.c
+++ b/src/deepblu_cosmiq.c
@@ -297,7 +297,7 @@ deepblu_cosmiq_recv_bulk (deepblu_cosmiq_device_t *device, dc_event_progress_t *
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
 
-	const unsigned int initial = progress ? progress->current : 0;
+	const size_t initial = progress ? progress->current : 0;
 
 	size_t nbytes = 0;
 	while (nbytes < size) {

--- a/src/deepsix_excursion.c
+++ b/src/deepsix_excursion.c
@@ -454,7 +454,7 @@ deepsix_excursion_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 		}
 
 		unsigned char *data = dc_buffer_get_data(buffer);
-		unsigned int   size = dc_buffer_get_size(buffer);
+		size_t         size = dc_buffer_get_size(buffer);
 		if (callback && !callback (data, size, data + FP_OFFSET, sizeof(device->fingerprint), userdata)) {
 			break;
 		}

--- a/src/deepsix_excursion.c
+++ b/src/deepsix_excursion.c
@@ -455,7 +455,12 @@ deepsix_excursion_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 
 		unsigned char *data = dc_buffer_get_data(buffer);
 		size_t         size = dc_buffer_get_size(buffer);
-		if (callback && !callback (data, size, data + FP_OFFSET, sizeof(device->fingerprint), userdata)) {
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free;
+		}
+		if (callback && !callback (data, (unsigned int) size, data + FP_OFFSET, sizeof(device->fingerprint), userdata)) {
 			break;
 		}
 	}

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -94,7 +94,7 @@ static const dc_iterator_vtable_t dc_descriptor_iterator_vtable = {
  * actually used to identify individual models, identical values are assigned.
  */
 
-static const dc_descriptor_t g_descriptors[] = {
+static dc_descriptor_t g_descriptors[] = {
 	/* Suunto Solution */
 	{"Suunto", "Solution", DC_FAMILY_SUUNTO_SOLUTION, 0, DC_TRANSPORT_SERIAL, NULL},
 	/* Suunto Eon */
@@ -1013,14 +1013,7 @@ dc_descriptor_iterator_next (dc_iterator_t *abstract, void *out)
 	if (iterator->current >= C_ARRAY_SIZE (g_descriptors))
 		return DC_STATUS_DONE;
 
-	/*
-	 * The explicit cast from a const to a non-const pointer is safe here. The
-	 * public interface doesn't support write access, and therefore descriptor
-	 * objects are always read-only. However, the cast allows to return a direct
-	 * reference to the entries in the table, avoiding the overhead of
-	 * allocating (and freeing) memory for a deep copy.
-	 */
-	*item = (dc_descriptor_t *) &g_descriptors[iterator->current++];
+	*item = &g_descriptors[iterator->current++];
 
 	return DC_STATUS_SUCCESS;
 }

--- a/src/device-private.h
+++ b/src/device-private.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define EVENT_PROGRESS_INITIALIZER {0, SIZE_MAX}
+#define EVENT_PROGRESS_INITIALIZER {0, UINT_MAX}
 
 struct dc_device_t;
 struct dc_device_vtable_t;

--- a/src/device-private.h
+++ b/src/device-private.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define EVENT_PROGRESS_INITIALIZER {0, UINT_MAX}
+#define EVENT_PROGRESS_INITIALIZER {0, SIZE_MAX}
 
 struct dc_device_t;
 struct dc_device_vtable_t;
@@ -92,7 +92,7 @@ int
 device_is_cancelled (dc_device_t *device);
 
 dc_status_t
-device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[], unsigned int size, unsigned int blocksize);
+device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[], size_t size, unsigned int blocksize);
 
 #ifdef __cplusplus
 }

--- a/src/device.c
+++ b/src/device.c
@@ -371,13 +371,15 @@ device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[
 {
 	if (device == NULL)
 		return DC_STATUS_UNSUPPORTED;
+	if (size > UINT_MAX)
+		return DC_STATUS_INVALIDARGS;
 
 	if (device->vtable->read == NULL)
 		return DC_STATUS_UNSUPPORTED;
 
 	// Enable progress notifications.
 	dc_event_progress_t progress = EVENT_PROGRESS_INITIALIZER;
-	progress.maximum = size;
+	progress.maximum = (unsigned int) size;
 	device_event_emit (device, DC_EVENT_PROGRESS, &progress);
 
 	size_t nbytes = 0;

--- a/src/device.c
+++ b/src/device.c
@@ -367,7 +367,7 @@ dc_device_dump (dc_device_t *device, dc_buffer_t *buffer)
 
 
 dc_status_t
-device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[], unsigned int size, unsigned int blocksize)
+device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[], size_t size, unsigned int blocksize)
 {
 	if (device == NULL)
 		return DC_STATUS_UNSUPPORTED;
@@ -380,15 +380,18 @@ device_dump_read (dc_device_t *device, unsigned int address, unsigned char data[
 	progress.maximum = size;
 	device_event_emit (device, DC_EVENT_PROGRESS, &progress);
 
-	unsigned int nbytes = 0;
+	size_t nbytes = 0;
 	while (nbytes < size) {
 		// Calculate the packet size.
-		unsigned int len = size - nbytes;
+		size_t len = size - nbytes;
 		if (len > blocksize)
 			len = blocksize;
 
 		// Read the packet.
-		dc_status_t rc = device->vtable->read (device, address + nbytes, data + nbytes, len);
+		if (nbytes > UINT_MAX || len > UINT_MAX || address > UINT_MAX - nbytes)
+			return DC_STATUS_INVALIDARGS;
+
+		dc_status_t rc = device->vtable->read (device, address + (unsigned int) nbytes, data + nbytes, (unsigned int) len);
 		if (rc != DC_STATUS_SUCCESS)
 			return rc;
 

--- a/src/diverite_nitekq.c
+++ b/src/diverite_nitekq.c
@@ -73,7 +73,7 @@ static const dc_device_vtable_t diverite_nitekq_device_vtable = {
 };
 
 static dc_status_t
-diverite_nitekq_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+diverite_nitekq_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 static dc_status_t
 diverite_nitekq_send (diverite_nitekq_device_t *device, unsigned char cmd)
@@ -342,7 +342,7 @@ diverite_nitekq_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 
 
 static dc_status_t
-diverite_nitekq_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+diverite_nitekq_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	diverite_nitekq_device_t *device = (diverite_nitekq_device_t *) abstract;
 	dc_context_t *context = (abstract ? abstract->context : NULL);

--- a/src/divesoft_freedom.c
+++ b/src/divesoft_freedom.c
@@ -580,8 +580,14 @@ divesoft_freedom_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 			status = DC_STATUS_PROTOCOL;
 			goto error_free_buffer;
 		}
+		size_t dive_size = dc_buffer_get_size (buffer);
+		if (dive_size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free_buffer;
+		}
 
-		if (callback && !callback (dc_buffer_get_data(buffer), dc_buffer_get_size(buffer), fingerprint, sizeof (device->fingerprint), userdata)) {
+		if (callback && !callback (dc_buffer_get_data(buffer), (unsigned int) dive_size, fingerprint, sizeof (device->fingerprint), userdata)) {
 			break;
 		}
 

--- a/src/divesystem_idive.c
+++ b/src/divesystem_idive.c
@@ -578,7 +578,12 @@ divesystem_idive_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 
 		unsigned char *data = dc_buffer_get_data(buffer);
 		size_t         size = dc_buffer_get_size(buffer);
-		if (callback && !callback (data, size, data + 7, sizeof(device->fingerprint), userdata)) {
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			dc_buffer_free (buffer);
+			return DC_STATUS_DATAFORMAT;
+		}
+		if (callback && !callback (data, (unsigned int) size, data + 7, sizeof(device->fingerprint), userdata)) {
 			dc_buffer_free (buffer);
 			return DC_STATUS_SUCCESS;
 		}
@@ -865,10 +870,15 @@ divesystem_idive_device_fwupdate (dc_device_t *abstract, const char *filename)
 	// Cache the data and size.
 	const unsigned char *data = dc_buffer_get_data (buffer);
 	size_t size = dc_buffer_get_size (buffer);
+	if (size > UINT_MAX) {
+		ERROR (abstract->context, "Firmware file is too large.");
+		status = DC_STATUS_INVALIDARGS;
+		goto error_free;
+	}
 
 	// Enable progress notifications.
 	dc_event_progress_t progress = EVENT_PROGRESS_INITIALIZER;
-	progress.maximum = size;
+	progress.maximum = (unsigned int) size;
 	device_event_emit (abstract, DC_EVENT_PROGRESS, &progress);
 
 	// Activate the bootloader.

--- a/src/divesystem_idive.c
+++ b/src/divesystem_idive.c
@@ -577,7 +577,7 @@ divesystem_idive_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 		}
 
 		unsigned char *data = dc_buffer_get_data(buffer);
-		unsigned int   size = dc_buffer_get_size(buffer);
+		size_t         size = dc_buffer_get_size(buffer);
 		if (callback && !callback (data, size, data + 7, sizeof(device->fingerprint), userdata)) {
 			dc_buffer_free (buffer);
 			return DC_STATUS_SUCCESS;

--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -285,7 +285,7 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 		goto error_exit;
 	}
 
-	const size_t initial = progress ? progress->current : 0;
+	const unsigned int initial = progress ? progress->current : 0;
 
 	unsigned int counter = 1;
 	unsigned int nbytes = 0;
@@ -346,7 +346,7 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 		if (progress) {
 			// Limit the progress events to the announced length.
 			unsigned int n = nbytes > length ? length : nbytes;
-			progress->current = initial + STEP(n, length);
+			progress->current = initial + (unsigned int) STEP(n, length);
 			device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
 		}
 
@@ -463,7 +463,7 @@ halcyon_symbios_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 	// Emit a vendor event.
 	dc_event_vendor_t vendor;
 	vendor.data = info;
-	vendor.size = info_size;
+	vendor.size = (unsigned int) info_size;
 	device_event_emit (abstract, DC_EVENT_VENDOR, &vendor);
 
 	// Emit a device info event.
@@ -557,7 +557,13 @@ halcyon_symbios_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 			goto error_free;
 		}
 
-		if (callback && !callback (dc_buffer_get_data (dive), dc_buffer_get_size (dive), data + offset + FP_OFFSET, FP_SIZE, userdata)) {
+		size_t dive_size = dc_buffer_get_size (dive);
+		if (dive_size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free;
+		}
+		if (callback && !callback (dc_buffer_get_data (dive), (unsigned int) dive_size, data + offset + FP_OFFSET, FP_SIZE, userdata)) {
 			break;
 		}
 	}

--- a/src/halcyon_symbios.c
+++ b/src/halcyon_symbios.c
@@ -121,12 +121,12 @@ halcyon_symbios_send (halcyon_symbios_device_t *device, unsigned char cmd, const
 }
 
 static dc_status_t
-halcyon_symbios_recv (halcyon_symbios_device_t *device, unsigned char cmd, unsigned char data[], unsigned int size, unsigned int *actual, unsigned int *errorcode)
+halcyon_symbios_recv (halcyon_symbios_device_t *device, unsigned char cmd, unsigned char data[], unsigned int size, size_t *actual, unsigned int *errorcode)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
 	unsigned char packet[2 + MAXPACKET + 1] = {0};
-	unsigned int length = 0;
+	size_t length = 0;
 	unsigned int errcode = 0;
 
 	// Receive the answer.
@@ -210,7 +210,7 @@ error_exit:
 }
 
 static dc_status_t
-halcyon_symbios_transfer (halcyon_symbios_device_t *device, unsigned char cmd, const unsigned char data[], unsigned int size, unsigned char answer[], unsigned int asize, unsigned int *actual, unsigned int *errorcode)
+halcyon_symbios_transfer (halcyon_symbios_device_t *device, unsigned char cmd, const unsigned char data[], unsigned int size, unsigned char answer[], unsigned int asize, size_t *actual, unsigned int *errorcode)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
@@ -224,7 +224,7 @@ halcyon_symbios_transfer (halcyon_symbios_device_t *device, unsigned char cmd, c
 	}
 
 	// Receive the answer.
-	unsigned int length = 0;
+	size_t length = 0;
 	status = halcyon_symbios_recv (device, cmd, answer, asize, &length, &errcode);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to receive the answer.");
@@ -234,7 +234,7 @@ halcyon_symbios_transfer (halcyon_symbios_device_t *device, unsigned char cmd, c
 	if (actual == NULL) {
 		// Verify the length of the packet.
 		if (length != asize) {
-			ERROR (abstract->context, "Unexpected packet length (%u).", length);
+			ERROR (abstract->context, "Unexpected packet length (" DC_PRINTF_SIZE ").", length);
 			status = DC_STATUS_PROTOCOL;
 			goto error_exit;
 		}
@@ -285,13 +285,13 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 		goto error_exit;
 	}
 
-	const unsigned int initial = progress ? progress->current : 0;
+	const size_t initial = progress ? progress->current : 0;
 
 	unsigned int counter = 1;
 	unsigned int nbytes = 0;
 	while (1) {
 		// Receive the data block.
-		unsigned int len = 0;
+		size_t len = 0;
 		unsigned char payload[2 + SZ_BLOCK] = {0};
 		unsigned int nretries = 0;
 		while ((status = halcyon_symbios_recv (device, block, payload, sizeof(payload), &len, NULL)) != DC_STATUS_SUCCESS) {
@@ -317,7 +317,7 @@ halcyon_symbios_download (halcyon_symbios_device_t *device, dc_event_progress_t 
 
 		// Verify the minimum block length.
 		if (len < 2) {
-			ERROR (abstract->context, "Unexpected block length (%u).", len);
+			ERROR (abstract->context, "Unexpected block length (" DC_PRINTF_SIZE ").", len);
 			status = DC_STATUS_PROTOCOL;
 			goto error_exit;
 		}
@@ -444,7 +444,7 @@ halcyon_symbios_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 
 	// Read the device status.
 	unsigned char info[36] = {0};
-	unsigned int info_size = 0;
+	size_t info_size = 0;
 	status = halcyon_symbios_transfer (device, CMD_GET_STATUS, NULL, 0, info, sizeof(info), &info_size, NULL);
 	if (status != DC_STATUS_SUCCESS) {
 		ERROR (abstract->context, "Failed to read the device status.");
@@ -453,7 +453,7 @@ halcyon_symbios_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 
 	// Verify the length of the packet.
 	if (info_size < 20) {
-		ERROR (abstract->context, "Unexpected packet length (%u).", info_size);
+		ERROR (abstract->context, "Unexpected packet length (" DC_PRINTF_SIZE ").", info_size);
 		status = DC_STATUS_PROTOCOL;
 		goto error_exit;
 	}
@@ -515,7 +515,7 @@ halcyon_symbios_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 
 	// Get the number of dives.
 	unsigned int ndives = 0;
-	unsigned int offset = size;
+	size_t offset = size;
 	while (offset >= SZ_LOGBOOK) {
 		offset -= SZ_LOGBOOK;
 

--- a/src/hw_ostc.c
+++ b/src/hw_ostc.c
@@ -82,7 +82,7 @@ static const dc_device_vtable_t hw_ostc_device_vtable = {
 };
 
 static dc_status_t
-hw_ostc_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+hw_ostc_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 static dc_status_t
 hw_ostc_send (hw_ostc_device_t *device, unsigned char cmd, unsigned int echo)
@@ -246,7 +246,7 @@ hw_ostc_device_dump (dc_device_t *abstract, dc_buffer_t *buffer)
 	unsigned int nbytes = sizeof (header);
 	while (nbytes < size) {
 		// Set the minimum packet size.
-		unsigned int len = 1024;
+		size_t len = 1024;
 
 		// Increase the packet size if more data is immediately available.
 		size_t available = 0;
@@ -595,7 +595,7 @@ hw_ostc_device_screenshot (dc_device_t *abstract, dc_buffer_t *buffer, hw_ostc_f
 
 
 static dc_status_t
-hw_ostc_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+hw_ostc_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	hw_ostc_device_t *device = (hw_ostc_device_t *) abstract;
 

--- a/src/hw_ostc.c
+++ b/src/hw_ostc.c
@@ -622,11 +622,14 @@ hw_ostc_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t
 		if (previous) {
 			// Move the pointer to the end of the footer.
 			previous += sizeof (footer);
+			size_t dive_size = previous - current;
+			if (dive_size > UINT_MAX)
+				return DC_STATUS_DATAFORMAT;
 
 			if (device && memcmp (current + 3, device->fingerprint, sizeof (device->fingerprint)) == 0)
 				return DC_STATUS_SUCCESS;
 
-			if (callback && !callback (current, previous - current, current + 3, 5, userdata))
+			if (callback && !callback (current, (unsigned int) dive_size, current + 3, 5, userdata))
 				return DC_STATUS_SUCCESS;
 		}
 

--- a/src/hw_ostc3.c
+++ b/src/hw_ostc3.c
@@ -1624,10 +1624,15 @@ hw_ostc3_device_fwupdate4 (dc_device_t *abstract, const char *filename)
 	if (status != DC_STATUS_SUCCESS) {
 		goto error;
 	}
+	if (dc_buffer_get_size (buffer) > UINT_MAX) {
+		ERROR (context, "Firmware file is too large.");
+		status = DC_STATUS_INVALIDARGS;
+		goto error;
+	}
 
 	// Enable progress notifications.
 	dc_event_progress_t progress = EVENT_PROGRESS_INITIALIZER;
-	progress.maximum = dc_buffer_get_size (buffer);
+	progress.maximum = (unsigned int) dc_buffer_get_size (buffer);
 	device_event_emit (abstract, DC_EVENT_PROGRESS, &progress);
 
 	// Cache the pointer and size.

--- a/src/hw_ostc3.c
+++ b/src/hw_ostc3.c
@@ -1177,11 +1177,11 @@ hw_ostc3_device_config_reset (dc_device_t *abstract)
 // This is a variant of fletcher16 with a 16 bit sum instead of an 8 bit sum,
 // and modulo 2^16 instead of 2^16-1
 static unsigned int
-hw_ostc3_firmware_checksum (const unsigned char data[], unsigned int size)
+hw_ostc3_firmware_checksum (const unsigned char data[], size_t size)
 {
 	unsigned short low = 0;
 	unsigned short high = 0;
-	for (unsigned int i = 0; i < size; i++) {
+	for (size_t i = 0; i < size; i++) {
 		low  += data[i];
 		high += low;
 	}
@@ -1632,9 +1632,9 @@ hw_ostc3_device_fwupdate4 (dc_device_t *abstract, const char *filename)
 
 	// Cache the pointer and size.
 	const unsigned char *data = dc_buffer_get_data (buffer);
-	unsigned int size = dc_buffer_get_size (buffer);
+	size_t size = dc_buffer_get_size (buffer);
 
-	unsigned int offset = 0;
+	size_t offset = 0;
 	while (offset + 4 <= size) {
 		// Get the length of the firmware blob.
 		unsigned int length = array_uint32_be(data + offset) + 20;

--- a/src/mares_darwin.c
+++ b/src/mares_darwin.c
@@ -94,7 +94,7 @@ static const mares_darwin_layout_t mares_darwinair_layout = {
 };
 
 static dc_status_t
-mares_darwin_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+mares_darwin_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 mares_darwin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream, unsigned int model)
@@ -246,7 +246,7 @@ mares_darwin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback,
 
 
 static dc_status_t
-mares_darwin_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+mares_darwin_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	mares_darwin_device_t *device = (mares_darwin_device_t *) abstract;
 

--- a/src/mares_iconhd.c
+++ b/src/mares_iconhd.c
@@ -229,7 +229,7 @@ mares_iconhd_packet_fixed (mares_iconhd_device_t *device,
 	unsigned char cmd,
 	const unsigned char data[], unsigned int size,
 	unsigned char answer[], unsigned int asize,
-	unsigned int *actual)
+	size_t *actual)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
@@ -314,7 +314,7 @@ mares_iconhd_packet_variable (mares_iconhd_device_t *device,
 	unsigned char cmd,
 	const unsigned char data[], unsigned int size,
 	unsigned char answer[], unsigned int asize,
-	unsigned int *actual)
+	size_t *actual)
 {
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_device_t *abstract = (dc_device_t *) device;
@@ -399,7 +399,7 @@ mares_iconhd_packet (mares_iconhd_device_t *device,
 	unsigned char cmd,
 	const unsigned char data[], unsigned int size,
 	unsigned char answer[], unsigned int asize,
-	unsigned int *actual)
+	size_t *actual)
 {
 	dc_transport_t transport = dc_iostream_get_transport (device->iostream);
 
@@ -411,7 +411,7 @@ mares_iconhd_packet (mares_iconhd_device_t *device,
 }
 
 static dc_status_t
-mares_iconhd_transfer (mares_iconhd_device_t *device, unsigned char cmd, const unsigned char data[], unsigned int size, unsigned char answer[], unsigned int asize, unsigned int *actual)
+mares_iconhd_transfer (mares_iconhd_device_t *device, unsigned char cmd, const unsigned char data[], unsigned int size, unsigned char answer[], unsigned int asize, size_t *actual)
 {
 	unsigned int nretries = 0;
 	dc_status_t rc = DC_STATUS_SUCCESS;
@@ -444,7 +444,7 @@ mares_iconhd_read_object(mares_iconhd_device_t *device, dc_event_progress_t *pro
 		504;
 
 	// Update and emit a progress event.
-	unsigned int initial = 0;
+	size_t initial = 0;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
@@ -513,7 +513,7 @@ mares_iconhd_read_object(mares_iconhd_device_t *device, dc_event_progress_t *pro
 		}
 
 		// Transfer the segment packet.
-		unsigned int length = 0;
+		size_t length = 0;
 		unsigned char rsp_segment[1 + 504];
 		status = mares_iconhd_transfer (device, cmd, NULL, 0, rsp_segment, len + 1, &length);
 		if (status != DC_STATUS_SUCCESS) {
@@ -522,7 +522,7 @@ mares_iconhd_read_object(mares_iconhd_device_t *device, dc_event_progress_t *pro
 		}
 
 		if (length < 1) {
-			ERROR (abstract->context, "Unexpected packet length (%u).", length);
+			ERROR (abstract->context, "Unexpected packet length (" DC_PRINTF_SIZE ").", length);
 			return DC_STATUS_PROTOCOL;
 		}
 

--- a/src/mares_iconhd.c
+++ b/src/mares_iconhd.c
@@ -444,7 +444,7 @@ mares_iconhd_read_object(mares_iconhd_device_t *device, dc_event_progress_t *pro
 		504;
 
 	// Update and emit a progress event.
-	size_t initial = 0;
+	unsigned int initial = 0;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
@@ -1143,7 +1143,13 @@ mares_iconhd_device_foreach_object (dc_device_t *abstract, dc_dive_callback_t ca
 		}
 
 		const unsigned char *data = dc_buffer_get_data (buffer);
-		if (callback && !callback (data, dc_buffer_get_size (buffer), data + 0x08, device->fingerprint_size, userdata)) {
+		size_t size = dc_buffer_get_size (buffer);
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			rc = DC_STATUS_DATAFORMAT;
+			break;
+		}
+		if (callback && !callback (data, (unsigned int) size, data + 0x08, device->fingerprint_size, userdata)) {
 			break;
 		}
 	}

--- a/src/mclean_extreme.c
+++ b/src/mclean_extreme.c
@@ -311,7 +311,7 @@ mclean_extreme_readdive (dc_device_t *abstract, dc_event_progress_t *progress, u
 	};
 
 	// Update and emit a progress event.
-	size_t initial = 0;
+	unsigned int initial = 0;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
@@ -347,7 +347,7 @@ mclean_extreme_readdive (dc_device_t *abstract, dc_event_progress_t *progress, u
 
 	// Update and emit a progress event.
 	if (progress) {
-		progress->current = initial + STEP(sizeof(header), size);
+		progress->current = initial + (unsigned int) STEP(sizeof(header), size);
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
 	}
 
@@ -606,11 +606,16 @@ mclean_extreme_device_foreach(dc_device_t *abstract, dc_dive_callback_t callback
 		// Cache the pointer.
 		unsigned char *data = dc_buffer_get_data(buffer);
 		size_t size = dc_buffer_get_size(buffer);
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_buffer_free;
+		}
 
 		if (memcmp(data + SZ_CFG, device->fingerprint, sizeof(device->fingerprint)) == 0)
 			break;
 
-		if (callback && !callback (data, size, data + SZ_CFG, sizeof(device->fingerprint), userdata)) {
+		if (callback && !callback (data, (unsigned int) size, data + SZ_CFG, sizeof(device->fingerprint), userdata)) {
 			break;
 		}
 	}

--- a/src/mclean_extreme.c
+++ b/src/mclean_extreme.c
@@ -91,10 +91,10 @@ hashcode (const unsigned char data[], size_t size)
 }
 
 static unsigned short
-checksum_crc(const unsigned char data[], unsigned int size, unsigned short init)
+checksum_crc(const unsigned char data[], size_t size, unsigned short init)
 {
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		crc ^= data[i] << 8;
 		if (crc & 0x8000) {
 			crc <<= 1;
@@ -311,7 +311,7 @@ mclean_extreme_readdive (dc_device_t *abstract, dc_event_progress_t *progress, u
 	};
 
 	// Update and emit a progress event.
-	unsigned int initial = 0;
+	size_t initial = 0;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);
@@ -505,7 +505,7 @@ mclean_extreme_device_timesync(dc_device_t *abstract, const dc_datetime_t *datet
 	}
 
 	// Adjust the epoch.
-	unsigned int timestamp = ticks - EPOCH;
+	unsigned int timestamp = (unsigned int) (ticks - EPOCH);
 
 	// Send the command.
 	const unsigned char cmd[] = {
@@ -605,7 +605,7 @@ mclean_extreme_device_foreach(dc_device_t *abstract, dc_dive_callback_t callback
 
 		// Cache the pointer.
 		unsigned char *data = dc_buffer_get_data(buffer);
-		unsigned int size = dc_buffer_get_size(buffer);
+		size_t size = dc_buffer_get_size(buffer);
 
 		if (memcmp(data + SZ_CFG, device->fingerprint, sizeof(device->fingerprint)) == 0)
 			break;

--- a/src/oceanic_common.c
+++ b/src/oceanic_common.c
@@ -459,7 +459,7 @@ oceanic_common_device_profile (dc_device_t *abstract, dc_event_progress_t *progr
 
 	// Cache the logbook pointer and size.
 	const unsigned char *logbooks = dc_buffer_get_data (logbook);
-	unsigned int rb_logbook_size = dc_buffer_get_size (logbook);
+	size_t rb_logbook_size = dc_buffer_get_size (logbook);
 
 	// Go through the logbook entries a first time, to get the end of
 	// profile pointer and calculate the total amount of bytes in the
@@ -474,7 +474,7 @@ oceanic_common_device_profile (dc_device_t *abstract, dc_event_progress_t *progr
 	// of the memory buffer.
 	unsigned int remaining = layout->rb_profile_end - layout->rb_profile_begin;
 	unsigned int previous = rb_profile_end;
-	unsigned int entry = rb_logbook_size;
+	size_t entry = rb_logbook_size;
 	while (entry) {
 		// Move to the start of the current entry.
 		entry -= layout->rb_logbook_entry_size;
@@ -561,7 +561,7 @@ oceanic_common_device_profile (dc_device_t *abstract, dc_event_progress_t *progr
 	}
 
 	// Keep track of the current position.
-	unsigned int offset = rb_profile_size + rb_logbook_size;
+	size_t offset = rb_profile_size + rb_logbook_size;
 
 	// Traverse the logbook ringbuffer backwards to retrieve the most recent
 	// dives first. The logbook ringbuffer is linearized at this point, so

--- a/src/oceans_s1.c
+++ b/src/oceans_s1.c
@@ -677,8 +677,14 @@ oceans_s1_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback, vo
 
 		unsigned char fingerprint[SZ_FINGERPRINT] = {0};
 		array_uint64_be_set (fingerprint, dive->timestamp);
+		size_t dive_size = dc_buffer_get_size (buffer);
+		if (dive_size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_free_list;
+		}
 
-		if (callback && !callback (dc_buffer_get_data (buffer), dc_buffer_get_size (buffer), fingerprint, sizeof(fingerprint), userdata))
+		if (callback && !callback (dc_buffer_get_data (buffer), (unsigned int) dive_size, fingerprint, sizeof(fingerprint), userdata))
 			break;
 	}
 

--- a/src/oceans_s1_common.c
+++ b/src/oceans_s1_common.c
@@ -22,6 +22,7 @@
 #include <string.h> // memcmp, memcpy
 #include <stdlib.h> // malloc, free
 #include <stddef.h>
+#include <limits.h>
 
 #include "oceans_s1_common.h"
 
@@ -64,5 +65,7 @@ oceans_s1_getline (char **line, size_t *linelen, const unsigned char **data, siz
 	*data += len;
 	*size -= len;
 
-	return len - strip;
+	if (len - strip > INT_MAX)
+		return -1;
+	return (int) (len - strip);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -255,6 +255,9 @@ dc_parser_new2 (dc_parser_t **out, dc_context_t *context, dc_descriptor_t *descr
 dc_parser_t *
 dc_parser_allocate (dc_context_t *context, const dc_parser_vtable_t *vtable, const unsigned char data[], size_t size)
 {
+	if (size > UINT_MAX)
+		return NULL;
+
 	dc_parser_t *parser = NULL;
 
 	assert(vtable != NULL);
@@ -282,7 +285,7 @@ dc_parser_allocate (dc_context_t *context, const dc_parser_vtable_t *vtable, con
 
 		// Copy the data.
 		memcpy (parser->data, data, size);
-		parser->size = size;
+		parser->size = (unsigned int) size;
 	} else {
 		parser->data = NULL;
 		parser->size = 0;

--- a/src/pelagic_i330r.c
+++ b/src/pelagic_i330r.c
@@ -319,8 +319,8 @@ pelagic_i330r_init_passcode (pelagic_i330r_device_t *device, const char *pincode
 	}
 
 	// Convert to binary number.
-	unsigned int offset = sizeof(passcode) - len;
-	for (unsigned int i = 0; i < len; i++) {
+	size_t offset = sizeof(passcode) - len;
+	for (size_t i = 0; i < len; i++) {
 		unsigned char c = pincode[i];
 		if (c < '0' || c > '9') {
 			ERROR (abstract->context, "Invalid pincode character (%c).", c);

--- a/src/reefnet_sensus.c
+++ b/src/reefnet_sensus.c
@@ -61,7 +61,7 @@ static const dc_device_vtable_t reefnet_sensus_device_vtable = {
 };
 
 static dc_status_t
-reefnet_sensus_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+reefnet_sensus_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 static dc_status_t
 reefnet_sensus_cancel (reefnet_sensus_device_t *device)
@@ -357,7 +357,7 @@ reefnet_sensus_device_foreach (dc_device_t *abstract, dc_dive_callback_t callbac
 
 
 static dc_status_t
-reefnet_sensus_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+reefnet_sensus_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	reefnet_sensus_device_t *device = (reefnet_sensus_device_t*) abstract;
 	dc_context_t *context = (abstract ? abstract->context : NULL);
@@ -366,8 +366,8 @@ reefnet_sensus_extract_dives (dc_device_t *abstract, const unsigned char data[],
 		return DC_STATUS_INVALIDARGS;
 
 	// Search the entire data stream for start markers.
-	unsigned int previous = size;
-	unsigned int current = (size >= 7 ? size - 7 : 0);
+	size_t previous = size;
+	size_t current = (size >= 7 ? size - 7 : 0);
 	while (current > 0) {
 		current--;
 		if (data[current] == 0xFF && data[current + 6] == 0xFE) {
@@ -376,7 +376,7 @@ reefnet_sensus_extract_dives (dc_device_t *abstract, const unsigned char data[],
 			// limited to the start of the previous dive.
 			int found = 0;
 			unsigned int nsamples = 0, count = 0;
-			unsigned int offset = current + 7; // Skip non-sample data.
+			size_t offset = current + 7; // Skip non-sample data.
 			while (offset + 1 <= previous) {
 				// Depth (adjusted feet of seawater).
 				unsigned char depth = data[offset++];

--- a/src/reefnet_sensus.c
+++ b/src/reefnet_sensus.c
@@ -414,8 +414,11 @@ reefnet_sensus_extract_dives (dc_device_t *abstract, const unsigned char data[],
 			unsigned int timestamp = array_uint32_le (data + current + 2);
 			if (device && timestamp <= device->timestamp)
 				return DC_STATUS_SUCCESS;
+			size_t dive_size = offset - current;
+			if (dive_size > UINT_MAX)
+				return DC_STATUS_DATAFORMAT;
 
-			if (callback && !callback (data + current, offset - current, data + current + 2, 4, userdata))
+			if (callback && !callback (data + current, (unsigned int) dive_size, data + current + 2, 4, userdata))
 				return DC_STATUS_SUCCESS;
 
 			// Prepare for the next dive.

--- a/src/reefnet_sensuspro.c
+++ b/src/reefnet_sensuspro.c
@@ -384,8 +384,11 @@ reefnet_sensuspro_extract_dives (dc_device_t *abstract, const unsigned char data
 			unsigned int timestamp = array_uint32_le (data + current + 6);
 			if (device && timestamp <= device->timestamp)
 				return DC_STATUS_SUCCESS;
+			size_t dive_size = offset + 2 - current;
+			if (dive_size > UINT_MAX)
+				return DC_STATUS_DATAFORMAT;
 
-			if (callback && !callback (data + current, offset + 2 - current, data + current + 6, 4, userdata))
+			if (callback && !callback (data + current, (unsigned int) dive_size, data + current + 6, 4, userdata))
 				return DC_STATUS_SUCCESS;
 
 			// Prepare for the next dive.

--- a/src/reefnet_sensuspro.c
+++ b/src/reefnet_sensuspro.c
@@ -59,7 +59,7 @@ static const dc_device_vtable_t reefnet_sensuspro_device_vtable = {
 };
 
 static dc_status_t
-reefnet_sensuspro_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+reefnet_sensuspro_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 reefnet_sensuspro_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
@@ -346,7 +346,7 @@ reefnet_sensuspro_device_write_interval (dc_device_t *abstract, unsigned char in
 
 
 static dc_status_t
-reefnet_sensuspro_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+reefnet_sensuspro_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	reefnet_sensuspro_device_t *device = (reefnet_sensuspro_device_t*) abstract;
 
@@ -357,8 +357,8 @@ reefnet_sensuspro_extract_dives (dc_device_t *abstract, const unsigned char data
 	const unsigned char footer[2] = {0xFF, 0xFF};
 
 	// Search the entire data stream for start markers.
-	unsigned int previous = size;
-	unsigned int current = (size >= 4 ? size - 4 : 0);
+	size_t previous = size;
+	size_t current = (size >= 4 ? size - 4 : 0);
 	while (current > 0) {
 		current--;
 		if (memcmp (data + current, header, sizeof (header)) == 0) {
@@ -366,7 +366,7 @@ reefnet_sensuspro_extract_dives (dc_device_t *abstract, const unsigned char data
 			// for the corresponding stop marker. The search is
 			// now limited to the start of the previous dive.
 			int found = 0;
-			unsigned int offset = current + 10; // Skip non-sample data.
+			size_t offset = current + 10; // Skip non-sample data.
 			while (offset + 2 <= previous) {
 				if (memcmp (data + offset, footer, sizeof (footer)) == 0) {
 					found = 1;

--- a/src/reefnet_sensusultra.c
+++ b/src/reefnet_sensusultra.c
@@ -606,6 +606,9 @@ reefnet_sensusultra_parse (reefnet_sensusultra_device_t *device,
 		if (previous) {
 			// Move the pointer to the end of the footer.
 			previous += sizeof (footer);
+			size_t dive_size = previous - current;
+			if (dive_size > UINT_MAX)
+				return DC_STATUS_DATAFORMAT;
 
 			// Automatically abort when a dive is older than the provided timestamp.
 			unsigned int timestamp = array_uint32_le (current + 4);
@@ -615,7 +618,7 @@ reefnet_sensusultra_parse (reefnet_sensusultra_device_t *device,
 				return DC_STATUS_SUCCESS;
 			}
 
-			if (callback && !callback (current, previous - current, current + 4, 4, userdata)) {
+			if (callback && !callback (current, (unsigned int) dive_size, current + 4, 4, userdata)) {
 				if (aborted)
 					*aborted = 1;
 				return DC_STATUS_SUCCESS;

--- a/src/reefnet_sensusultra.c
+++ b/src/reefnet_sensusultra.c
@@ -573,7 +573,7 @@ reefnet_sensusultra_device_sense (dc_device_t *abstract, unsigned char *data, un
 
 static dc_status_t
 reefnet_sensusultra_parse (reefnet_sensusultra_device_t *device,
-	const unsigned char data[], unsigned int *premaining, unsigned int *pprevious,
+	const unsigned char data[], size_t *premaining, size_t *pprevious,
 	int *aborted, dc_dive_callback_t callback, void *userdata)
 {
 	const unsigned char header[4] = {0x00, 0x00, 0x00, 0x00};
@@ -665,8 +665,8 @@ reefnet_sensusultra_device_foreach (dc_device_t *abstract, dc_dive_callback_t ca
 	}
 
 	// Initialize the state for the incremental parser.
-	unsigned int remaining = 0;
-	unsigned int previous = 0;
+	size_t remaining = 0;
+	size_t previous = 0;
 
 	unsigned int nbytes = 0;
 	unsigned int npages = 0;

--- a/src/seac_screen.c
+++ b/src/seac_screen.c
@@ -152,7 +152,7 @@ seac_screen_send (seac_screen_device_t *device, unsigned short cmd, const unsign
 		return DC_STATUS_INVALIDARGS;
 
 	// Setup the data packet
-	unsigned len = size + 6;
+	size_t len = size + 6;
 	unsigned char packet[SZ_MAXCMD + 7] = {
 		START,
 		(len >> 8) & 0xFF,
@@ -242,7 +242,7 @@ seac_screen_receive (seac_screen_device_t *device, unsigned short cmd, unsigned 
 	}
 
 	// Verify the length of the packet.
-	unsigned int expected = (type == ACK ? size : 1) + 7;
+	size_t expected = (type == ACK ? size : 1) + 7;
 	if (length != expected) {
 		ERROR (abstract->context, "Unexpected packet length (%u).", length);
 		return DC_STATUS_PROTOCOL;

--- a/src/shearwater_common.c
+++ b/src/shearwater_common.c
@@ -469,7 +469,7 @@ shearwater_common_download (shearwater_common_device_t *device, dc_buffer_t *buf
 	}
 
 	// Enable progress notifications.
-	size_t initial = 0, current = 0, maximum = 3 + size + 1;
+	unsigned int initial = 0, current = 0, maximum = 3 + size + 1;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);

--- a/src/shearwater_common.c
+++ b/src/shearwater_common.c
@@ -146,11 +146,11 @@ shearwater_common_decompress_lre (unsigned char *data, unsigned int size, dc_buf
 
 
 static int
-shearwater_common_decompress_xor (unsigned char *data, unsigned int size)
+shearwater_common_decompress_xor (unsigned char *data, size_t size)
 {
 	// Each block of 32 bytes is XOR'ed (in-place) with the previous block,
 	// except for the first block, which is passed through unchanged.
-	for (unsigned int i = 32; i < size; ++i) {
+	for (size_t i = 32; i < size; ++i) {
 		data[i] ^= data[i - 32];
 	}
 
@@ -469,7 +469,7 @@ shearwater_common_download (shearwater_common_device_t *device, dc_buffer_t *buf
 	}
 
 	// Enable progress notifications.
-	unsigned int initial = 0, current = 0, maximum = 3 + size + 1;
+	size_t initial = 0, current = 0, maximum = 3 + size + 1;
 	if (progress) {
 		initial = progress->current;
 		device_event_emit (abstract, DC_EVENT_PROGRESS, progress);

--- a/src/shearwater_petrel.c
+++ b/src/shearwater_petrel.c
@@ -263,7 +263,7 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 
 		// Cache the buffer pointer and size.
 		unsigned char *data = dc_buffer_get_data (buffer);
-		unsigned int size = dc_buffer_get_size (buffer);
+		size_t size = dc_buffer_get_size (buffer);
 
 		// Process the records in the manifest.
 		unsigned int count = 0, deleted = 0;
@@ -312,9 +312,9 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 
 	// Cache the buffer pointer and size.
 	unsigned char *data = dc_buffer_get_data (manifests);
-	unsigned int size = dc_buffer_get_size (manifests);
+	size_t size = dc_buffer_get_size (manifests);
 
-	unsigned int offset = 0;
+	size_t offset = 0;
 	while (offset < size) {
 		// skip deleted dives
 		if (array_uint16_be(data + offset) == 0x5A23) {
@@ -339,7 +339,7 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 		current += 1;
 
 		unsigned char *buf = dc_buffer_get_data (buffer);
-		unsigned int len = dc_buffer_get_size (buffer);
+		size_t len = dc_buffer_get_size (buffer);
 		if (callback && !callback (buf, len, buf + 12, sizeof (device->fingerprint), userdata))
 			break;
 

--- a/src/shearwater_petrel.c
+++ b/src/shearwater_petrel.c
@@ -340,7 +340,12 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
 
 		unsigned char *buf = dc_buffer_get_data (buffer);
 		size_t len = dc_buffer_get_size (buffer);
-		if (callback && !callback (buf, len, buf + 12, sizeof (device->fingerprint), userdata))
+		if (len > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			rc = DC_STATUS_DATAFORMAT;
+			break;
+		}
+		if (callback && !callback (buf, (unsigned int) len, buf + 12, sizeof (device->fingerprint), userdata))
 			break;
 
 		offset += RECORD_SIZE;

--- a/src/shearwater_predator.c
+++ b/src/shearwater_predator.c
@@ -59,7 +59,7 @@ static const dc_device_vtable_t shearwater_predator_device_vtable = {
 };
 
 static dc_status_t
-shearwater_predator_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+shearwater_predator_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 shearwater_predator_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
@@ -171,7 +171,7 @@ shearwater_predator_device_foreach (dc_device_t *abstract, dc_dive_callback_t ca
 
 
 static dc_status_t
-shearwater_predator_extract_predator (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+shearwater_predator_extract_predator (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	shearwater_predator_device_t *device = (shearwater_predator_device_t*) abstract;
 	dc_context_t *context = (abstract ? abstract->context : NULL);
@@ -280,7 +280,7 @@ shearwater_predator_extract_predator (dc_device_t *abstract, const unsigned char
 
 
 static dc_status_t
-shearwater_predator_extract_petrel (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+shearwater_predator_extract_petrel (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	shearwater_predator_device_t *device = (shearwater_predator_device_t*) abstract;
 	dc_context_t *context = (abstract ? abstract->context : NULL);
@@ -342,7 +342,7 @@ shearwater_predator_extract_petrel (dc_device_t *abstract, const unsigned char d
 
 
 static dc_status_t
-shearwater_predator_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+shearwater_predator_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	if (abstract && !ISINSTANCE (abstract))
 		return DC_STATUS_INVALIDARGS;

--- a/src/suunto_eon.c
+++ b/src/suunto_eon.c
@@ -141,11 +141,11 @@ suunto_eon_device_dump (dc_device_t *abstract, dc_buffer_t *buffer)
 	}
 
 	// Receive the answer.
-	unsigned int nbytes = 0;
+	size_t nbytes = 0;
 	unsigned char answer[SZ_MEMORY + 1] = {0};
 	while (nbytes < sizeof(answer)) {
 		// Set the minimum packet size.
-		unsigned int len = 64;
+		size_t len = 64;
 
 		// Increase the packet size if more data is immediately available.
 		size_t available = 0;

--- a/src/suunto_eonsteel.c
+++ b/src/suunto_eonsteel.c
@@ -787,8 +787,14 @@ suunto_eonsteel_device_foreach(dc_device_t *abstract, dc_dive_callback_t callbac
 
 			data = dc_buffer_get_data(file);
 			size = dc_buffer_get_size(file);
+			if (size > UINT_MAX) {
+				ERROR (abstract->context, "Dive data is too large.");
+				dc_status_set_error(&status, DC_STATUS_DATAFORMAT);
+				skip = 1;
+				break;
+			}
 
-			if (callback && !callback(data, size, data, sizeof(eon->fingerprint), userdata))
+			if (callback && !callback(data, (unsigned int) size, data, sizeof(eon->fingerprint), userdata))
 				skip = 1;
 		}
 		progress.current++;

--- a/src/suunto_eonsteel.c
+++ b/src/suunto_eonsteel.c
@@ -135,12 +135,12 @@ static struct directory_entry *alloc_dirent(int type, int len, const char *name)
  * The maximum payload is 62 bytes.
  */
 static dc_status_t
-suunto_eonsteel_receive_usb(suunto_eonsteel_device_t *device, unsigned char data[], unsigned int size, unsigned int *actual)
+suunto_eonsteel_receive_usb(suunto_eonsteel_device_t *device, unsigned char data[], size_t size, size_t *actual)
 {
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	unsigned char buf[PACKET_SIZE];
 	size_t transferred = 0;
-	unsigned int len = 0;
+	size_t len = 0;
 
 	rc = dc_iostream_read(device->iostream, buf, sizeof(buf), &transferred);
 	if (rc != DC_STATUS_SUCCESS) {
@@ -160,7 +160,7 @@ suunto_eonsteel_receive_usb(suunto_eonsteel_device_t *device, unsigned char data
 
 	len = buf[1];
 	if (len + 2 > transferred) {
-		ERROR(device->base.context, "Invalid payload length (%u).", len);
+		ERROR(device->base.context, "Invalid payload length (" DC_PRINTF_SIZE ").", len);
 		return DC_STATUS_PROTOCOL;
 	}
 	if (len > size) {
@@ -179,7 +179,7 @@ suunto_eonsteel_receive_usb(suunto_eonsteel_device_t *device, unsigned char data
 }
 
 static dc_status_t
-suunto_eonsteel_receive_ble(suunto_eonsteel_device_t *device, unsigned char data[], unsigned int size, unsigned int *actual)
+suunto_eonsteel_receive_ble(suunto_eonsteel_device_t *device, unsigned char data[], unsigned int size, size_t *actual)
 {
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	unsigned char buffer[HEADER_SIZE + MAXDATA_SIZE + CRC_SIZE];
@@ -196,7 +196,7 @@ suunto_eonsteel_receive_ble(suunto_eonsteel_device_t *device, unsigned char data
 		return DC_STATUS_PROTOCOL;
 	}
 
-	unsigned int nbytes = transferred - CRC_SIZE;
+	size_t nbytes = transferred - CRC_SIZE;
 
 	unsigned int crc = array_uint32_le(buffer + nbytes);
 	unsigned int ccrc = checksum_crc32r(buffer, nbytes);
@@ -294,11 +294,11 @@ suunto_eonsteel_transfer(suunto_eonsteel_device_t *device,
 	unsigned short cmd,
 	const unsigned char data[], unsigned int size,
 	unsigned char answer[], unsigned int asize,
-	unsigned int *actual)
+	size_t *actual)
 {
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	unsigned char header[HEADER_SIZE + MAXDATA_SIZE];
-	unsigned int len = 0;
+	size_t len = 0;
 
 	// Send the command.
 	rc = suunto_eonsteel_send(device, cmd, data, size);
@@ -317,7 +317,7 @@ suunto_eonsteel_transfer(suunto_eonsteel_device_t *device,
 
 	// Verify the header length.
 	if (len < HEADER_SIZE) {
-		ERROR(device->base.context, "Invalid packet length (%u).", len);
+		ERROR(device->base.context, "Invalid packet length (" DC_PRINTF_SIZE ").", len);
 		return DC_STATUS_PROTOCOL;
 	}
 
@@ -354,9 +354,9 @@ suunto_eonsteel_transfer(suunto_eonsteel_device_t *device,
 	}
 
 	// Verify the initial payload length.
-	unsigned int nbytes = len - HEADER_SIZE;
+	size_t nbytes = len - HEADER_SIZE;
 	if (nbytes > length) {
-		ERROR(device->base.context, "Unexpected number of bytes (received %u, expected %u).", nbytes, length);
+		ERROR(device->base.context, "Unexpected number of bytes (received " DC_PRINTF_SIZE ", expected %u).", nbytes, length);
 		return DC_STATUS_PROTOCOL;
 	}
 
@@ -379,7 +379,7 @@ suunto_eonsteel_transfer(suunto_eonsteel_device_t *device,
 
 	// Verify the total payload length.
 	if (nbytes != length) {
-		ERROR(device->base.context, "Unexpected number of bytes (received %u, expected %u).", nbytes, length);
+		ERROR(device->base.context, "Unexpected number of bytes (received " DC_PRINTF_SIZE ", expected %u).", nbytes, length);
 		return DC_STATUS_PROTOCOL;
 	}
 
@@ -403,8 +403,8 @@ read_file(suunto_eonsteel_device_t *eon, const char *filename, dc_buffer_t *buf)
 	dc_status_t rc = DC_STATUS_SUCCESS;
 	unsigned char result[2560];
 	unsigned char cmdbuf[64];
-	unsigned int size, offset, len;
-	unsigned int n = 0;
+	size_t size, offset, len;
+	size_t n = 0;
 
 	memset(cmdbuf, 0, sizeof(cmdbuf));
 	len = strlen(filename) + 1;
@@ -414,7 +414,7 @@ read_file(suunto_eonsteel_device_t *eon, const char *filename, dc_buffer_t *buf)
 	}
 	memcpy(cmdbuf+4, filename, len);
 	rc = suunto_eonsteel_transfer(eon, CMD_FILE_OPEN,
-		cmdbuf, len + 4, result, sizeof(result), &n);
+		cmdbuf, (unsigned int) (len + 4), result, sizeof(result), &n);
 	if (rc != DC_STATUS_SUCCESS) {
 		ERROR(eon->base.context, "unable to look up %s", filename);
 		return rc;
@@ -435,9 +435,7 @@ read_file(suunto_eonsteel_device_t *eon, const char *filename, dc_buffer_t *buf)
 	while (size > 0) {
 		unsigned int ask, got, at;
 
-		ask = size;
-		if (ask > 1024)
-			ask = 1024;
+		ask = size > 1024 ? 1024 : (unsigned int) size;
 		array_uint32_le_set(cmdbuf + 0, 1234);	// Not file offset, after all
 		array_uint32_le_set(cmdbuf + 4, ask);	// Size of read
 		rc = suunto_eonsteel_transfer(eon, CMD_FILE_READ,
@@ -454,7 +452,7 @@ read_file(suunto_eonsteel_device_t *eon, const char *filename, dc_buffer_t *buf)
 		// Not file offset, just stays unmodified.
 		at = array_uint32_le(result);
 		if (at != 1234) {
-			ERROR(eon->base.context, "read of %s returned different offset than asked for (%d vs %d)", filename, at, offset);
+	ERROR(eon->base.context, "read of %s returned different offset than asked for (%u vs " DC_PRINTF_SIZE ")", filename, at, offset);
 			return DC_STATUS_PROTOCOL;
 		}
 
@@ -463,12 +461,12 @@ read_file(suunto_eonsteel_device_t *eon, const char *filename, dc_buffer_t *buf)
 		if (!got)
 			break;
 		if (n < 8 + got) {
-			ERROR(eon->base.context, "odd read size reply for offset %d of file %s", offset, filename);
+		ERROR(eon->base.context, "odd read size reply for offset " DC_PRINTF_SIZE " of file %s", offset, filename);
 			return DC_STATUS_PROTOCOL;
 		}
 
 		if (got > size)
-			got = size;
+			got = (unsigned int) size;
 		if (!dc_buffer_append (buf, result + 8, got)) {
 			ERROR (eon->base.context, "Insufficient buffer space available.");
 			return DC_STATUS_NOMEMORY;
@@ -549,7 +547,7 @@ get_file_list(suunto_eonsteel_device_t *eon, struct directory_entry **res)
 	struct directory_entry *de = NULL;
 	unsigned char cmd[64];
 	unsigned char result[2048];
-	unsigned int n = 0;
+	size_t n = 0;
 	unsigned int cmdlen;
 
 	array_uint32_le_set(cmd, 0);
@@ -582,7 +580,7 @@ get_file_list(suunto_eonsteel_device_t *eon, struct directory_entry **res)
 		last = array_uint32_le(result+4);
 		HEXDUMP(eon->base.context, DC_LOGLEVEL_DEBUG, "dir packet", result, 8);
 
-		de = parse_dirent(eon, nr, result+8, n-8, de);
+	de = parse_dirent(eon, nr, result+8, (unsigned int) (n - 8), de);
 		if (last)
 			break;
 	}
@@ -743,7 +741,7 @@ suunto_eonsteel_device_foreach(dc_device_t *abstract, dc_dive_callback_t callbac
 		struct directory_entry *next = de->next;
 		unsigned char buf[4];
 		const unsigned char *data = NULL;
-		unsigned int size = 0;
+		size_t size = 0;
 
 		if (device_is_cancelled(abstract)) {
 			dc_status_set_error(&status, DC_STATUS_CANCELLED);

--- a/src/suunto_eonsteel_parser.c
+++ b/src/suunto_eonsteel_parser.c
@@ -1020,7 +1020,11 @@ static dc_status_t
 suunto_eonsteel_parser_samples_foreach(dc_parser_t *abstract, dc_sample_callback_t callback, void *userdata)
 {
 	suunto_eonsteel_parser_t *eon = (suunto_eonsteel_parser_t *) abstract;
-	struct sample_data data = { eon, callback, userdata, 0 };
+	struct sample_data data = {
+		.eon = eon,
+		.callback = callback,
+		.userdata = userdata,
+	};
 
 	traverse_data(eon, traverse_samples, &data);
 

--- a/src/suunto_eonsteel_parser.c
+++ b/src/suunto_eonsteel_parser.c
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <ctype.h>
 #include <math.h>
 
@@ -306,10 +307,14 @@ static int record_type(suunto_eonsteel_parser_t *eon, unsigned short type, const
 
 		next = strchr(name, '\n');
 		if (next) {
-			len = next - name;
+			if (next - name > INT_MAX)
+				return -1;
+			len = (int) (next - name);
 			next++;
 		} else {
-			len = strlen(name);
+			if (strlen(name) > INT_MAX)
+				return -1;
+			len = (int) strlen(name);
 			if (!len)
 				break;
 		}
@@ -429,7 +434,9 @@ static int traverse_entry(suunto_eonsteel_parser_t *eon, const unsigned char *p,
 		end += len;
 	}
 
-	return end - p;
+	if (end - p > INT_MAX)
+		return -1;
+	return (int) (end - p);
 }
 
 static int traverse_data(suunto_eonsteel_parser_t *eon, eon_data_cb_t callback, void *user)

--- a/src/suunto_solution.c
+++ b/src/suunto_solution.c
@@ -57,7 +57,7 @@ static const dc_device_vtable_t suunto_solution_device_vtable = {
 };
 
 static dc_status_t
-suunto_solution_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+suunto_solution_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 suunto_solution_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
@@ -255,7 +255,7 @@ suunto_solution_device_foreach (dc_device_t *abstract, dc_dive_callback_t callba
 
 
 static dc_status_t
-suunto_solution_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+suunto_solution_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	if (abstract && !ISINSTANCE (abstract))
 		return DC_STATUS_INVALIDARGS;

--- a/src/suunto_vyper.c
+++ b/src/suunto_vyper.c
@@ -513,7 +513,7 @@ suunto_vyper_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback,
 	unsigned int remaining = layout->rb_profile_end - layout->rb_profile_begin;
 	while ((rc = suunto_vyper_read_dive (abstract, buffer, (ndives == 0), &progress)) == DC_STATUS_SUCCESS) {
 		unsigned char *data = dc_buffer_get_data (buffer);
-		unsigned int size = dc_buffer_get_size (buffer);
+		size_t size = dc_buffer_get_size (buffer);
 
 		if (size > remaining) {
 			ERROR (abstract->context, "Unexpected number of bytes received.");

--- a/src/suunto_vyper.c
+++ b/src/suunto_vyper.c
@@ -531,7 +531,7 @@ suunto_vyper_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback,
 			return DC_STATUS_SUCCESS;
 		}
 
-		if (callback && !callback (data, size, data + layout->fp_offset, sizeof (device->fingerprint), userdata)) {
+		if (callback && !callback (data, (unsigned int) size, data + layout->fp_offset, sizeof (device->fingerprint), userdata)) {
 			dc_buffer_free (buffer);
 			return DC_STATUS_SUCCESS;
 		}

--- a/src/suunto_vyper2.c
+++ b/src/suunto_vyper2.c
@@ -230,7 +230,9 @@ suunto_vyper2_device_packet (dc_device_t *abstract, const unsigned char command[
 		// resolution on all platforms. The higher resolution is
 		// pointless anyway, since we already added a fudge factor
 		// above.
-		dc_iostream_sleep (device->iostream, (remaining + 999) / 1000);
+		if (remaining > (dc_usecs_t) UINT_MAX * 1000)
+			return DC_STATUS_INVALIDARGS;
+		dc_iostream_sleep (device->iostream, (unsigned int) ((remaining + 999) / 1000));
 	}
 
 	// Clear RTS to receive the reply.

--- a/src/tecdiving_divecomputereu.c
+++ b/src/tecdiving_divecomputereu.c
@@ -529,6 +529,11 @@ tecdiving_divecomputereu_device_foreach (dc_device_t *abstract, dc_dive_callback
 		// Cache the pointer.
 		unsigned char *data = dc_buffer_get_data(buffer);
 		size_t size = dc_buffer_get_size(buffer);
+		if (size > UINT_MAX) {
+			ERROR (abstract->context, "Dive data is too large.");
+			status = DC_STATUS_DATAFORMAT;
+			goto error_buffer_free;
+		}
 
 		// Verify the logbook entry.
 		if (memcmp (data, logbook + offset, SZ_SUMMARY) != 0) {
@@ -537,7 +542,7 @@ tecdiving_divecomputereu_device_foreach (dc_device_t *abstract, dc_dive_callback
 			goto error_buffer_free;
 		}
 
-		if (callback && !callback (data, size, data, sizeof(device->fingerprint), userdata)) {
+		if (callback && !callback (data, (unsigned int) size, data, sizeof(device->fingerprint), userdata)) {
 			break;
 		}
 	}

--- a/src/tecdiving_divecomputereu.c
+++ b/src/tecdiving_divecomputereu.c
@@ -78,10 +78,10 @@ static const dc_device_vtable_t tecdiving_divecomputereu_device_vtable = {
 };
 
 static unsigned short
-checksum_crc (const unsigned char data[], unsigned int size, unsigned short init)
+checksum_crc (const unsigned char data[], size_t size, unsigned short init)
 {
 	unsigned short crc = init;
-	for (unsigned int i = 0; i < size; ++i) {
+	for (size_t i = 0; i < size; ++i) {
 		crc ^= data[i] << 8;
 		if (crc & 0x8000) {
 			crc <<= 1;
@@ -528,7 +528,7 @@ tecdiving_divecomputereu_device_foreach (dc_device_t *abstract, dc_dive_callback
 
 		// Cache the pointer.
 		unsigned char *data = dc_buffer_get_data(buffer);
-		unsigned int size = dc_buffer_get_size(buffer);
+		size_t size = dc_buffer_get_size(buffer);
 
 		// Verify the logbook entry.
 		if (memcmp (data, logbook + offset, SZ_SUMMARY) != 0) {

--- a/src/usb.c
+++ b/src/usb.c
@@ -295,9 +295,10 @@ dc_usb_iterator_new (dc_iterator_t **out, dc_context_t *context, dc_descriptor_t
 	struct libusb_device **devices = NULL;
 	ssize_t ndevices = libusb_get_device_list (iterator->session->handle, &devices);
 	if (ndevices < 0) {
+		int error = ndevices < INT_MIN ? LIBUSB_ERROR_OTHER : (int) ndevices;
 		ERROR (context, "Failed to enumerate the usb devices (%s).",
-			libusb_error_name (ndevices));
-		status = syserror (ndevices);
+			libusb_error_name (error));
+		status = syserror (error);
 		goto error_session_unref;
 	}
 
@@ -550,8 +551,10 @@ dc_usb_read (dc_iostream_t *abstract, void *data, size_t size, size_t *actual)
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_usb_t *usb = (dc_usb_t *) abstract;
 	int nbytes = 0;
+	if (size > INT_MAX)
+		return DC_STATUS_INVALIDARGS;
 
-	int rc = libusb_bulk_transfer (usb->handle, usb->endpoint_in, data, size, &nbytes, usb->timeout);
+	int rc = libusb_bulk_transfer (usb->handle, usb->endpoint_in, data, (int) size, &nbytes, usb->timeout);
 	if (rc != LIBUSB_SUCCESS || nbytes < 0) {
 		ERROR (abstract->context, "Usb read bulk transfer failed (%s).",
 			libusb_error_name (rc));
@@ -574,8 +577,20 @@ dc_usb_write (dc_iostream_t *abstract, const void *data, size_t size, size_t *ac
 	dc_status_t status = DC_STATUS_SUCCESS;
 	dc_usb_t *usb = (dc_usb_t *) abstract;
 	int nbytes = 0;
+	unsigned char dummy = 0;
+	unsigned char *buffer = &dummy;
 
-	int rc = libusb_bulk_transfer (usb->handle, usb->endpoint_out, (void *) data, size, &nbytes, 0);
+	if (size > INT_MAX)
+		return DC_STATUS_INVALIDARGS;
+
+	if (size > 0) {
+		buffer = (unsigned char *) malloc (size);
+		if (buffer == NULL)
+			return DC_STATUS_NOMEMORY;
+		memcpy (buffer, data, size);
+	}
+
+	int rc = libusb_bulk_transfer (usb->handle, usb->endpoint_out, buffer, (int) size, &nbytes, 0);
 	if (rc != LIBUSB_SUCCESS || nbytes < 0) {
 		ERROR (abstract->context, "Usb write bulk transfer failed (%s).",
 			libusb_error_name (rc));
@@ -586,6 +601,8 @@ dc_usb_write (dc_iostream_t *abstract, const void *data, size_t size, size_t *ac
 	}
 
 out:
+	if (size > 0)
+		free (buffer);
 	if (actual)
 		*actual = nbytes;
 

--- a/src/uwatec_aladin.c
+++ b/src/uwatec_aladin.c
@@ -65,7 +65,7 @@ static const dc_device_vtable_t uwatec_aladin_device_vtable = {
 };
 
 static dc_status_t
-uwatec_aladin_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+uwatec_aladin_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 uwatec_aladin_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
@@ -261,7 +261,7 @@ uwatec_aladin_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback
 
 
 static dc_status_t
-uwatec_aladin_extract_dives (dc_device_t *abstract, const unsigned char* data, unsigned int size, dc_dive_callback_t callback, void *userdata)
+uwatec_aladin_extract_dives (dc_device_t *abstract, const unsigned char* data, size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	uwatec_aladin_device_t *device = (uwatec_aladin_device_t*) abstract;
 

--- a/src/uwatec_memomouse.c
+++ b/src/uwatec_memomouse.c
@@ -61,7 +61,7 @@ static const dc_device_vtable_t uwatec_memomouse_device_vtable = {
 };
 
 static dc_status_t
-uwatec_memomouse_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+uwatec_memomouse_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 dc_status_t
 uwatec_memomouse_device_open (dc_device_t **out, dc_context_t *context, dc_iostream_t *iostream)
@@ -466,7 +466,7 @@ uwatec_memomouse_device_foreach (dc_device_t *abstract, dc_dive_callback_t callb
 
 
 static dc_status_t
-uwatec_memomouse_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+uwatec_memomouse_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	if (abstract && !ISINSTANCE (abstract))
 		return DC_STATUS_INVALIDARGS;

--- a/src/uwatec_smart.c
+++ b/src/uwatec_smart.c
@@ -82,7 +82,7 @@ static const dc_device_vtable_t uwatec_smart_device_vtable = {
 };
 
 static dc_status_t
-uwatec_smart_extract_dives (dc_device_t *device, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata);
+uwatec_smart_extract_dives (dc_device_t *device, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata);
 
 static dc_status_t
 uwatec_smart_irda_send (uwatec_smart_device_t *device, unsigned char cmd, const unsigned char data[], size_t size)
@@ -373,7 +373,7 @@ uwatec_smart_usbhid_receive (uwatec_smart_device_t *device, dc_event_progress_t 
 		 *
 		 * It may be just an oddly implemented sequence number. Whatever.
 		 */
-		unsigned int len = transferred - 1;
+		size_t len = transferred - 1;
 		if (transport == DC_TRANSPORT_USBHID) {
 			if (len > buf[0])
 				len = buf[0];
@@ -708,7 +708,7 @@ uwatec_smart_device_foreach (dc_device_t *abstract, dc_dive_callback_t callback,
 
 
 static dc_status_t
-uwatec_smart_extract_dives (dc_device_t *abstract, const unsigned char data[], unsigned int size, dc_dive_callback_t callback, void *userdata)
+uwatec_smart_extract_dives (dc_device_t *abstract, const unsigned char data[], size_t size, dc_dive_callback_t callback, void *userdata)
 {
 	if (abstract && !ISINSTANCE (abstract))
 		return DC_STATUS_INVALIDARGS;
@@ -716,8 +716,8 @@ uwatec_smart_extract_dives (dc_device_t *abstract, const unsigned char data[], u
 	const unsigned char header[4] = {0xa5, 0xa5, 0x5a, 0x5a};
 
 	// Search the data stream for start markers.
-	unsigned int previous = size;
-	unsigned int current = (size >= 4 ? size - 4 : 0);
+	size_t previous = size;
+	size_t current = (size >= 4 ? size - 4 : 0);
 	while (current > 0) {
 		current--;
 		if (memcmp (data + current, header, sizeof (header)) == 0) {


### PR DESCRIPTION
The release version of libdivecomputer throws a lot of compiler warnings when compiled with xcode for distribution with Apple apps. The warnings bother my OCD, hence this PR. 

The underlying fixes promote in-memory lengths to size_t, preserve protocol-bound 32-bit values with validation, and correct related callback, progress, checksum, array, parser, logging, and timing types.